### PR TITLE
Transform Interface Refactor

### DIFF
--- a/transformer/app.py
+++ b/transformer/app.py
@@ -87,18 +87,20 @@ def transform_many(transform, inputs, data):
     take the inputs object and try to convert all of the inputs with the data provided
 
     """
+    data = data or {}
+
     if hasattr(transform, 'transform_many') and callable(transform.transform_many):
-        return transform.transform_many(inputs, data=data)
+        return transform.transform_many(inputs, **data)
     if isinstance(inputs, dict):
         outputs = {}
         for k, v in inputs.iteritems():
-            outputs[k] = transform.transform(v, data=data)
+            outputs[k] = transform.transform(v, **data)
     elif isinstance(inputs, list):
         outputs = []
         for v in inputs:
-            outputs.append(transform.transform(v, data=data))
+            outputs.append(transform.transform(v, **data))
     else:
-        outputs = transform.transform(inputs, data=data)
+        outputs = transform.transform(inputs, **data)
     return outputs
 
 

--- a/transformer/transforms/base.py
+++ b/transformer/transforms/base.py
@@ -31,7 +31,6 @@ class BaseTransform:
 
     def _fields_internal(self, *args, **kwargs):
         return [
-            # up to dev app to do the parent_key hack
             {
                 'type': 'unicode',
                 'list': True,

--- a/transformer/transforms/date/formatting.py
+++ b/transformer/transforms/date/formatting.py
@@ -11,13 +11,7 @@ class DateFormattingTransform(BaseTransform):
     label = 'Date / Formatting'
     help_text = 'Format a date into a specific format.'
 
-    def transform(self, date_value, data=None, **kwargs):
-        if data is None:
-            data = {}
-
-        from_format = data.get('from_format', '')
-        to_format = data.get('to_format', '')
-
+    def transform(self, date_value, from_format='', to_format='', **kwargs):
         dt = try_parse_date(date_value, from_format=from_format)
         if not dt:
             return self.raise_exception('Date could not be parsed')
@@ -25,8 +19,6 @@ class DateFormattingTransform(BaseTransform):
         return arrow.get(dt).to('utc').format(to_format)
 
     def fields(self, *args, **kwargs):
-        # Mon Jan 2 15:04:05 MST 2006
-
         dt = arrow.get(try_parse_date('Mon Jan 2 15:04:05 -0800 2006')).to('utc')
 
         formats = [

--- a/transformer/transforms/date/formatting_test.py
+++ b/transformer/transforms/date/formatting_test.py
@@ -4,45 +4,54 @@ import formatting
 class TestDateFormattingTransform(unittest.TestCase):
     def test_from_to_format(self):
         transformer = formatting.DateFormattingTransform()
-        self.assertEqual(transformer.transform('2016-01-01', {
-            'from_format': 'YYYY-MM-DD',
-            'to_format': 'MMMM DD, YYYY'
-        }), "January 01, 2016")
+        self.assertEqual(transformer.transform(
+            '2016-01-01',
+            from_format='YYYY-MM-DD',
+            to_format='MMMM DD, YYYY'
+        ), "January 01, 2016")
 
     def test_fuzzy_to_format(self):
         transformer = formatting.DateFormattingTransform()
-        self.assertEqual(transformer.transform('I ordered it on January 17, 2047 ok?', {
-            'to_format': 'MM-DD-YYYY'
-        }), "01-17-2047")
+        self.assertEqual(transformer.transform(
+            'I ordered it on January 17, 2047 ok?',
+            to_format='MM-DD-YYYY'
+        ), "01-17-2047")
 
     def test_fuzzy_relative_to_format(self):
         transformer = formatting.DateFormattingTransform()
-        self.assertNotEqual(transformer.transform('next friday', {
-            'to_format': 'MM-DD-YYYY'
-        }), "")
+        self.assertNotEqual(transformer.transform(
+            'next friday',
+            to_format='MM-DD-YYYY'
+        ), "")
 
     def test_parse_timestamp(self):
         transformer = formatting.DateFormattingTransform()
-        self.assertEqual(transformer.transform(1453498140, {
-            'to_format': 'MM-DD-YYYY'
-        }), "01-22-2016")
+        self.assertEqual(transformer.transform(
+            1453498140,
+            to_format='MM-DD-YYYY'
+        ), "01-22-2016")
 
-        self.assertEqual(transformer.transform(1453498140000, {
-            'to_format': 'MM-DD-YYYY'
-        }), "01-22-2016")
+        self.assertEqual(transformer.transform(
+            1453498140000,
+            to_format='MM-DD-YYYY'
+        ), "01-22-2016")
 
-        self.assertEqual(transformer.transform(1453498140.001, {
-            'to_format': 'MM-DD-YYYY'
-        }), "01-22-2016")
+        self.assertEqual(transformer.transform(
+            1453498140.001,
+            to_format='MM-DD-YYYY'
+        ), "01-22-2016")
 
-        self.assertEqual(transformer.transform('1453498140', {
-            'to_format': 'MM-DD-YYYY'
-        }), '01-22-2016')
+        self.assertEqual(transformer.transform(
+            '1453498140',
+            to_format='MM-DD-YYYY'
+        ), '01-22-2016')
 
-        self.assertEqual(transformer.transform('1453498140000', {
-            'to_format': 'MM-DD-YYYY'
-        }), '01-22-2016')
+        self.assertEqual(transformer.transform(
+            '1453498140000',
+            to_format='MM-DD-YYYY'
+        ), '01-22-2016')
 
-        self.assertEqual(transformer.transform('1453498140.001', {
-            'to_format': 'MM-DD-YYYY'
-        }), '01-22-2016')
+        self.assertEqual(transformer.transform(
+            '1453498140.001',
+            to_format='MM-DD-YYYY'
+        ), '01-22-2016')

--- a/transformer/transforms/date/manipulate.py
+++ b/transformer/transforms/date/manipulate.py
@@ -12,13 +12,7 @@ class DateManipulateTransform(BaseTransform):
     help_text = 'Manipulate a date and time by adding or subtracting '
     'days, months, years, hours, minutes, or seconds.'
 
-    def transform(self, date_value, data=None, **kwargs):
-        if data is None:
-            data = {}
-
-        expression = data.get('expression', '')
-        to_format = data.get('to_format', '')
-
+    def transform(self, date_value, expression='', to_format='', **kwargs):
         delta = tdelta(expression)
 
         dt = try_parse_date(date_value)

--- a/transformer/transforms/date/manipulate_test.py
+++ b/transformer/transforms/date/manipulate_test.py
@@ -4,22 +4,26 @@ import manipulate
 class TestDateManipulateTransform(unittest.TestCase):
     def test_basic_manipulate(self):
         transformer = manipulate.DateManipulateTransform()
-        self.assertEqual(transformer.transform('2016-01-01', {
-            'expression': '+1 month - 1 day',
-            'to_format': 'MMMM DD, YYYY'
-        }), "January 31, 2016")
+        self.assertEqual(transformer.transform(
+            '2016-01-01',
+            expression='+1 month - 1 day',
+            to_format='MMMM DD, YYYY'
+        ), "January 31, 2016")
 
-        self.assertEqual(transformer.transform('2016-01-01', {
-            'expression': '- 1 month - 1 day',
-            'to_format': 'MMMM DD, YYYY'
-        }), "November 30, 2015")
+        self.assertEqual(transformer.transform(
+            '2016-01-01',
+            expression='- 1 month - 1 day',
+            to_format='MMMM DD, YYYY'
+        ), "November 30, 2015")
 
-        self.assertEqual(transformer.transform('2016-01-01', {
-            'expression': '+ 1 year - 1 month - 1 day',
-            'to_format': 'MMMM DD, YYYY'
-        }), "November 30, 2016")
+        self.assertEqual(transformer.transform(
+            '2016-01-01',
+            expression='+ 1 year - 1 month - 1 day',
+            to_format='MMMM DD, YYYY'
+        ), "November 30, 2016")
 
-        self.assertEqual(transformer.transform('2016-02-01', {
-            'expression': '+ 1 month - 1 day',
-            'to_format': 'MMMM DD, YYYY'
-        }), "February 29, 2016")
+        self.assertEqual(transformer.transform(
+            '2016-02-01',
+            expression='+ 1 month - 1 day',
+            to_format='MMMM DD, YYYY'
+        ), "February 29, 2016")


### PR DESCRIPTION
Basically, instead of our contract with a transform being `def transform(self, input, data={})` where data is the set of fields returned from `transform.fields()`, we explode them out like `def transform(self, input, my_extra_arg='')`