### PR TITLE
Lookup Table

### DIFF
--- a/transformer/transforms/util/lookup.py
+++ b/transformer/transforms/util/lookup.py
@@ -41,7 +41,7 @@ class UtilLookupTransform(BaseTransform):
                 'key': 'fallback',
                 'label': 'Fallback Value',
                 'help_text': 'The value to be used if we do not find a corresponding value in Lookup Table.'
-            },
+            }
         ]
 
 register(UtilLookupTransform())

--- a/transformer/transforms/util/lookup.py
+++ b/transformer/transforms/util/lookup.py
@@ -1,0 +1,47 @@
+from transformer.registry import register
+from transformer.transforms.base import BaseTransform
+
+
+class UtilLookupTransform(BaseTransform):
+
+    category = 'util'
+    name = 'lookup'
+    label = 'Lookup Table'
+    help_text = 'Given a key and table - find the corresponding value.'
+
+    noun = 'Value'
+    verb = 'lookup in'
+
+    def build_input_field(self):
+        return {
+            'type': 'dict',
+            'required': False,
+            'key': 'table',
+            'label': 'Lookup Table',
+            'help_text': 'The table that will be used for the lookup - keys on the left and values on the right.',
+        }
+
+    def transform(self, table, key=u'', fallback=u'', **kwargs):
+        if key and key in table:
+            return table[key]
+        return fallback
+
+    def fields(self, *args, **kwargs):
+        return [
+            {
+                'type': 'unicode',
+                'required': False,
+                'key': 'key',
+                'label': 'Lookup Key',
+                'help_text': 'Given this key, look for a corresponding value in the Lookup Table.'
+            },
+            {
+                'type': 'unicode',
+                'required': False,
+                'key': 'fallback',
+                'label': 'Fallback Value',
+                'help_text': 'The value to be used if we do not find a corresponding value in Lookup Table.'
+            },
+        ]
+
+register(UtilLookupTransform())

--- a/transformer/transforms/util/lookup.py
+++ b/transformer/transforms/util/lookup.py
@@ -7,40 +7,31 @@ class UtilLookupTransform(BaseTransform):
     category = 'util'
     name = 'lookup'
     label = 'Lookup Table'
-    help_text = 'Given a key and table - find the corresponding value.'
+    help_text = 'Given a key and table - find the matching value.'
 
     noun = 'Value'
-    verb = 'lookup in'
+    verb = 'lookup'
 
-    def build_input_field(self):
-        return {
-            'type': 'dict',
-            'required': False,
-            'key': 'table',
-            'label': 'Lookup Table',
-            'help_text': 'The table that will be used for the lookup - keys on the left and values on the right.',
-        }
-
-    def transform(self, table, key=u'', fallback=u'', **kwargs):
-        if key and key in table:
-            return table[key]
+    def transform(self, input_key, table={}, fallback=u'', **kwargs):
+        if input_key and input_key in table:
+            return table[input_key]
         return fallback
 
     def fields(self, *args, **kwargs):
         return [
             {
-                'type': 'unicode',
+                'type': 'dict',
                 'required': False,
-                'key': 'key',
-                'label': 'Lookup Key',
-                'help_text': 'Given this key, look for a corresponding value in the Lookup Table.'
+                'key': 'table',
+                'label': 'Lookup Table',
+                'help_text': 'The table that will be used for the lookup - keys on the left and values on the right.',
             },
             {
                 'type': 'unicode',
                 'required': False,
                 'key': 'fallback',
                 'label': 'Fallback Value',
-                'help_text': 'The value to be used if we do not find a corresponding value in Lookup Table.'
+                'help_text': 'The value to be used if we do not find a matching value in Lookup Table.'
             }
         ]
 

--- a/transformer/transforms/util/lookup_test.py
+++ b/transformer/transforms/util/lookup_test.py
@@ -1,0 +1,11 @@
+import unittest
+import lookup
+
+class TestUtilLookupTransform(unittest.TestCase):
+    def test_lookup_empty(self):
+        transformer = lookup.UtilLookupTransform()
+
+        self.assertEquals(transformer.transform({'a': 1, 'b': 2}, key='a', fallback=3), 1)
+        self.assertEquals(transformer.transform({'a': 1, 'b': 2}, key='asfguy', fallback=3), 3)
+        self.assertEquals(transformer.transform({'a': 1, 'b': 2}, key='', fallback=3), 3)
+        self.assertEquals(transformer.transform({'a': 1, 'b': 2, '': 10}, key='', fallback=3), 3)

--- a/transformer/transforms/util/lookup_test.py
+++ b/transformer/transforms/util/lookup_test.py
@@ -14,3 +14,5 @@ class TestUtilLookupTransform(unittest.TestCase):
         self.assertEquals(transformer.transform(u'asfguy', table={'a': 1, u'b': 2}, fallback=3), 3)
         self.assertEquals(transformer.transform(u'', table={'a': 1, u'b': 2}, fallback=3), 3)
         self.assertEquals(transformer.transform(u'', table={'a': 1, u'b': 2, '': 10}, fallback=u'cat'), u'cat')
+
+        self.assertEquals(transformer.transform(u'nothing'), u'')

--- a/transformer/transforms/util/lookup_test.py
+++ b/transformer/transforms/util/lookup_test.py
@@ -5,7 +5,12 @@ class TestUtilLookupTransform(unittest.TestCase):
     def test_lookup_empty(self):
         transformer = lookup.UtilLookupTransform()
 
-        self.assertEquals(transformer.transform({'a': 1, 'b': 2}, key='a', fallback=3), 1)
-        self.assertEquals(transformer.transform({'a': 1, 'b': 2}, key='asfguy', fallback=3), 3)
-        self.assertEquals(transformer.transform({'a': 1, 'b': 2}, key='', fallback=3), 3)
-        self.assertEquals(transformer.transform({'a': 1, 'b': 2, '': 10}, key='', fallback=3), 3)
+        self.assertEquals(transformer.transform('a', table={'a': 1, 'b': 2}, fallback=3), 1)
+        self.assertEquals(transformer.transform('asfguy', table={'a': 1, 'b': 2}, fallback=3), 3)
+        self.assertEquals(transformer.transform('', table={'a': 1, 'b': 2}, fallback=3), 3)
+        self.assertEquals(transformer.transform('', table={'a': 1, 'b': 2, '': 10}, fallback=3), 3)
+
+        self.assertEquals(transformer.transform(u'a', table={'a': 1, u'b': 2}, fallback=3), 1)
+        self.assertEquals(transformer.transform(u'asfguy', table={'a': 1, u'b': 2}, fallback=3), 3)
+        self.assertEquals(transformer.transform(u'', table={'a': 1, u'b': 2}, fallback=3), 3)
+        self.assertEquals(transformer.transform(u'', table={'a': 1, u'b': 2, '': 10}, fallback=u'cat'), u'cat')


### PR DESCRIPTION
This will allow anyone to provide a lookup table to convert or assign a value to another value with a static list, for example:

```
cat: kitty
dog: puppy
parrot: noisy
```

And then if you input `dog` - we'll output `puppy`.

------

Not exactly sure how `transform_many` and options vs. first inpurt arg is selected - so @jsherer you mind checking me here?

The first arg is a `dict` type instead of a classic `str`/`unicode`.