### PR TITLE
Don't transform those empty fields.

### DIFF
--- a/transformer/transforms/date/formatting.py
+++ b/transformer/transforms/date/formatting.py
@@ -31,6 +31,9 @@ class DateFormattingTransform(BaseTransform):
     verb = 'format'
 
     def transform(self, date_value, from_format=u'', to_format=u'', **kwargs):
+        if not date_value:
+            return date_value
+
         dt = try_parse_date(date_value, from_format=from_format)
         if not dt:
             return self.raise_exception('Date could not be parsed')

--- a/transformer/transforms/date/formatting_test.py
+++ b/transformer/transforms/date/formatting_test.py
@@ -3,6 +3,7 @@ import formatting
 
 class TestDateFormattingTransform(unittest.TestCase):
     transformer = formatting.DateFormattingTransform()
+
     def test_transforming_empty_field_returns_empty_field(self):
         self.assertEqual(self.transformer.transform(
             '',
@@ -33,21 +34,18 @@ class TestDateFormattingTransform(unittest.TestCase):
         ), '2016-01-22')
 
     def test_fuzzy_to_format(self):
-        self.transformer = formatting.DateFormattingTransform()
         self.assertEqual(self.transformer.transform(
             'I ordered it on January 17, 2047 ok?',
             to_format='MM-DD-YYYY'
         ), "01-17-2047")
 
     def test_fuzzy_relative_to_format(self):
-        self.transformer = formatting.DateFormattingTransform()
         self.assertNotEqual(self.transformer.transform(
             'next friday',
             to_format='MM-DD-YYYY'
         ), "")
 
     def test_parse_timestamp(self):
-        self.transformer = formatting.DateFormattingTransform()
         self.assertEqual(self.transformer.transform(
             1453498140,
             to_format='MM-DD-YYYY'

--- a/transformer/transforms/date/formatting_test.py
+++ b/transformer/transforms/date/formatting_test.py
@@ -2,78 +2,84 @@ import unittest
 import formatting
 
 class TestDateFormattingTransform(unittest.TestCase):
-    def test_from_to_format(self):
-        transformer = formatting.DateFormattingTransform()
+    transformer = formatting.DateFormattingTransform()
+    def test_transforming_empty_field_returns_empty_field(self):
+        self.assertEqual(self.transformer.transform(
+            '',
+            from_format='MM/DD/YYYY',
+            to_format='YYYY-MM-DD'
+        ), '')
 
+    def test_from_to_format(self):
         # Try an ambiguous date with a month then days format
-        self.assertEqual(transformer.transform(
+        self.assertEqual(self.transformer.transform(
             '03/01/2016',
             from_format='MM/DD/YYYY',
             to_format='YYYY-MM-DD'
         ), '2016-03-01')
 
         # Flipping the format to days then months should yield a different output
-        self.assertEqual(transformer.transform(
+        self.assertEqual(self.transformer.transform(
             '03/01/2016',
             from_format='DD/MM/YYYY',
             to_format='YYYY-MM-DD'
         ), '2016-01-03')
 
         # If the from format is clearly wrong, we'll do the correct thing
-        self.assertEqual(transformer.transform(
+        self.assertEqual(self.transformer.transform(
             '22/01/2016',
             to_format='YYYY-MM-DD',
             from_format='MM/DD/YYYY'
         ), '2016-01-22')
 
     def test_fuzzy_to_format(self):
-        transformer = formatting.DateFormattingTransform()
-        self.assertEqual(transformer.transform(
+        self.transformer = formatting.DateFormattingTransform()
+        self.assertEqual(self.transformer.transform(
             'I ordered it on January 17, 2047 ok?',
             to_format='MM-DD-YYYY'
         ), "01-17-2047")
 
     def test_fuzzy_relative_to_format(self):
-        transformer = formatting.DateFormattingTransform()
-        self.assertNotEqual(transformer.transform(
+        self.transformer = formatting.DateFormattingTransform()
+        self.assertNotEqual(self.transformer.transform(
             'next friday',
             to_format='MM-DD-YYYY'
         ), "")
 
     def test_parse_timestamp(self):
-        transformer = formatting.DateFormattingTransform()
-        self.assertEqual(transformer.transform(
+        self.transformer = formatting.DateFormattingTransform()
+        self.assertEqual(self.transformer.transform(
             1453498140,
             to_format='MM-DD-YYYY'
         ), "01-22-2016")
 
-        self.assertEqual(transformer.transform(
+        self.assertEqual(self.transformer.transform(
             1453498140000,
             to_format='MM-DD-YYYY'
         ), "01-22-2016")
 
-        self.assertEqual(transformer.transform(
+        self.assertEqual(self.transformer.transform(
             1453498140.001,
             to_format='MM-DD-YYYY'
         ), "01-22-2016")
 
-        self.assertEqual(transformer.transform(
+        self.assertEqual(self.transformer.transform(
             '1453498140',
             to_format='MM-DD-YYYY'
         ), '01-22-2016')
 
-        self.assertEqual(transformer.transform(
+        self.assertEqual(self.transformer.transform(
             '1453498140000',
             to_format='MM-DD-YYYY'
         ), '01-22-2016')
 
-        self.assertEqual(transformer.transform(
+        self.assertEqual(self.transformer.transform(
             '1453498140.001',
             to_format='MM-DD-YYYY'
         ), '01-22-2016')
 
         # Including a from_format should prevent the usual timestamp parsing
-        self.assertEqual(transformer.transform(
+        self.assertEqual(self.transformer.transform(
             '01022016',
             to_format='YYYY-MM-DD',
             from_format='MMDDYYYY'


### PR DESCRIPTION
A customer was complaining that they need to use this, but since the date field is optional on the input they don't want this defaulting to today's date as it does now. 