### PR TITLE
Date + Timezones

### DIFF
--- a/transformer/transforms/date/formatting.py
+++ b/transformer/transforms/date/formatting.py
@@ -56,7 +56,7 @@ class DateFormattingTransform(BaseTransform):
 
         choices = ','.join(['{}|{} ({})'.format(f, f, dt.format(f)) for f in PREDEFINED_DATE_FORMATS])
 
-        timezones = list(sorted(pytz.all_timezones))
+        timezones = list(sorted(pytz.common_timezones, key=lambda v: '-' + v if v.startswith('US') else v))
 
         return [
             {

--- a/transformer/transforms/date/formatting.py
+++ b/transformer/transforms/date/formatting.py
@@ -78,19 +78,19 @@ class DateFormattingTransform(BaseTransform):
             {
                 'type': 'unicode',
                 'required': False,
+                'key': 'from_format',
+                'choices': choices,
+                'help_text': 'If we incorrectly interpret the incoming (input) date, set this to explicitly tell us the format. Otherwise, we will do our best to figure it out.' # NOQA
+            },
+            {
+                'type': 'unicode',
+                'required': False,
                 'key': 'from_timezone',
                 'label': 'From Timezone',
                 'choices': timezones,
                 'default': 'UTC',
                 'help_text': 'If no timezone is provided in the incoming (input) data, set this to explicitly tell us which to use. (Default: UTC)' # NOQA
             },
-            {
-                'type': 'unicode',
-                'required': False,
-                'key': 'from_format',
-                'choices': choices,
-                'help_text': 'If we incorrectly interpret the incoming (input) date, set this to explicitly tell us the format. Otherwise, we will do our best to figure it out.' # NOQA
-            }
         ]
 
 register(DateFormattingTransform())


### PR DESCRIPTION
Allow the transform to specify which timezone to convert to, along with an optional timezone to try to convert from if no timezone is specified in the input.

See: #26