### PR TITLE
Util Choose - Item Indexing

### DIFF
--- a/transformer/transforms/util/choose_test.py
+++ b/transformer/transforms/util/choose_test.py
@@ -55,6 +55,17 @@ class TestUtilChooseTransform(unittest.TestCase):
 
         self.assertEqual(2, transformer.transform_many(['', 2, 3, ''], options={'operation': 'first', 'default': 0}))
         self.assertEqual(3, transformer.transform_many(['', 2, 3, ''], options={'operation': 'last', 'default': 0}))
+        self.assertEqual(2, transformer.transform_many(['', 2, 3, ''], options={'operation': '0', 'default': 0}))
+        self.assertEqual(3, transformer.transform_many(['', 2, 3, ''], options={'operation': '-1', 'default': 0}))
 
         self.assertEqual('a', transformer.transform_many(['a', 2, 3, 'b'], options={'operation': 'first', 'default': 0}))
         self.assertEqual('b', transformer.transform_many(['a', 2, 3, 'b'], options={'operation': 'last', 'default': 0}))
+
+        self.assertEqual(2, transformer.transform_many(['a', 2, 3, 'b'], options={'operation': '1', 'default': 0}))
+        self.assertEqual('a', transformer.transform_many(['a', 2, 3, 'b'], options={'operation': '0', 'default': 0}))
+        self.assertEqual('b', transformer.transform_many(['a', 2, 3, 'b'], options={'operation': '-1', 'default': 0}))
+        self.assertEqual('a', transformer.transform_many(['a', 2, 3, 'b'], options={'operation': 0, 'default': 0}))
+        self.assertEqual('b', transformer.transform_many(['a', 2, 3, 'b'], options={'operation': -1, 'default': 0}))
+
+        # invalid op == default
+        self.assertEqual(0, transformer.transform_many(['a', 2, 3, 'b'], options={'operation': 'asdf', 'default': 0}))

--- a/transformer/util.py
+++ b/transformer/util.py
@@ -117,6 +117,8 @@ def try_parse_number(number_value, cls=float, default=0):
     try:
         return int_or_float(cls(number_value))
     except:
+        if default is None:
+            return default
         return cls(default)
 
 


### PR DESCRIPTION
Adds support for item indexing in the `util.choose` transform. Simplifies the choice logic a bit by relying solely on list indexing, instead of looping + counting. 

See: #29