### PR TITLE
Use `decimal.Decimal` exclusively in spreadsheet formulas

### DIFF
--- a/transformer/transforms/number/math_operation_test.py
+++ b/transformer/transforms/number/math_operation_test.py
@@ -15,3 +15,7 @@ class TestNumberMathTransform(unittest.TestCase):
         self.assertEqual(0, transformer.transform_many([None, 'Something'], options={'operation': 'add'}))
         self.assertEqual(1, transformer.transform_many(['Something', None, 1], options={'operation': 'add'}))
         self.assertEqual(0, transformer.transform_many(None, options={'operation': 'add'}))
+        self.assertEqual('55.23175', str(transformer.transform_many(
+            [4, 12.95, 1.06625],
+            options={'operation': 'mul'},
+        )))

--- a/transformer/transforms/number/spreadsheet_formula_test.py
+++ b/transformer/transforms/number/spreadsheet_formula_test.py
@@ -15,14 +15,17 @@ class TestNumberSpreadsheetStyleFormulaTransform(unittest.TestCase):
         self.assertEqual(6, transformer.transform(u'1 + 2 + 3'))
         self.assertEqual(-4, transformer.transform(u'1 - 2 - 3'))
         self.assertEqual(6, transformer.transform(u'1 * 2 * 3'))
-        self.assertEqual(0.16666666666666666, transformer.transform(u'1 / 2 / 3'))
+        self.assertEqual(
+            Decimal('0.1666666666666666666666666667'),
+            transformer.transform(u'1 / 2 / 3'),
+        )
 
         self.assertEqual(1, transformer.transform(u'(1 + 2) / 3 + MIN(0, 10)'))
 
         self.assertEqual(1, transformer.transform(u'MOD(1, 2)'))
         self.assertEqual(0, transformer.transform(u'MOD(2, 2)'))
 
-        self.assertEqual(0.01, transformer.transform(u'1%'))
+        self.assertEqual(Decimal('0.01'), transformer.transform(u'1%'))
 
         self.assertEqual(True, transformer.transform(u'MOD(2, 2) = 0'))
         self.assertEqual(True, transformer.transform(u'MOD(2, 2) <> 1'))
@@ -51,6 +54,13 @@ class TestNumberSpreadsheetStyleFormulaTransform(unittest.TestCase):
 
         # ROUND returns a Decimal object
         self.assertEqual(Decimal('8.39'), transformer.transform(u'ROUND(8.385, 2)'))
+
+        self.assertEqual(
+            Decimal('4078.715'),
+            transformer.transform(
+                u'=(135743*(0.5/100))+(135743*(0/100))+2050+1350',
+            ),
+        )
 
     def test_unicode_strings(self):
         transformer = spreadsheet_formula.NumberSpreadsheetStyleFormulaTransform()

--- a/transformer/util.py
+++ b/transformer/util.py
@@ -132,17 +132,17 @@ def try_parse_date(date_value, from_format=None):
         return datetime.datetime(*datetime.datetime.utcnow().utctimetuple()[:3])
 
 
-def int_or_decimal(v):
+def int_or_float(v):
     """
-    returns an int if the value is a long or int.
-    otherwise returns a `decimal.Decimal`.
+    returns an int if the value is a long or int or a float that can be
+    represented by an int...otherwise returns a float
     """
     if isinstance(v, int) or isinstance(v, long):
         return v
-    try:
+    if v.is_integer():
         return long(v)
-    except ValueError:
-        return Decimal(v)
+    return float(v)
+
 
 
 def try_parse_number(number_value, cls=float, default=0):
@@ -152,7 +152,7 @@ def try_parse_number(number_value, cls=float, default=0):
     if isinstance(number_value, int) or isinstance(number_value, long) or isinstance(number_value, float):
         return number_value
     try:
-        return int_or_decimal(cls(number_value))
+        return int_or_float(cls(number_value))
     except:
         if default is None:
             return default


### PR DESCRIPTION
The half-and-half use before was causing normal math operations to get
screwed up, and for complex spreadsheet formulas to return the incorrect
result.

Added tests for these cases to prevent regressions. In future it'd be
good if we could eliminate `float` entirely so that even normal math
operations don't suffer from issues with floating point precision.