### PR TITLE
Correctly handle CEILING/FLOOR when a factor is speficied.

### DIFF
--- a/transformer/transforms/number/spreadsheet_formula.py
+++ b/transformer/transforms/number/spreadsheet_formula.py
@@ -278,12 +278,12 @@ def func_lcm(a, b):
 
 def func_ceil(a, factor=1):
     """ functor for ceiling with factor factor """
-    return int(factor * math.ceil(Decimal(a) / factor))
+    return int(factor * Decimal(math.ceil(Decimal(a) / factor)))
 
 
 def func_floor(a, factor=1):
     """ functor for floor with factor factor """
-    return int(factor * math.floor(Decimal(a) / factor))
+    return int(factor * Decimal(math.floor(Decimal(a) / factor)))
 
 
 def func_even(a):

--- a/transformer/transforms/number/spreadsheet_formula_test.py
+++ b/transformer/transforms/number/spreadsheet_formula_test.py
@@ -61,7 +61,9 @@ class TestNumberSpreadsheetStyleFormulaTransform(unittest.TestCase):
     def test_int_output(self):
         operations = [
             'CEILING(-2.5)',
+            'CEILING(-2.5, .25)',
             'FLOOR(4.3)',
+            'FLOOR(-2.5, .25)',
             'EVEN(-4.3)',
             'INT(4.5)',
             'ODD(4.3)',


### PR DESCRIPTION
This was causing the remaining [`unsupported operand type(s) for *: 'Decimal' and 'float'` errors](https://logs.internal.zapier.com/search?rangetype=relative&fields=message%2Csource&width=1280&highlightMessage=&relative=7200&q=selected_api%3AZapierFormatterDevAPI+AND+object_action%3Anumber+AND+facility%3Arequestlog+AND+response_status_code%3A500+AND+%22unsupported+operand%22).