### PR TITLE
Stop casting ROUND/CEILING to ints.

### DIFF
--- a/transformer/transforms/number/spreadsheet_formula.py
+++ b/transformer/transforms/number/spreadsheet_formula.py
@@ -278,24 +278,24 @@ def func_lcm(a, b):
 
 def func_ceil(a, factor=1):
     """ functor for ceiling with factor factor """
-    return int(factor * Decimal(math.ceil(Decimal(a) / factor)))
+    return factor * Decimal(math.ceil(Decimal(a) / factor))
 
 
 def func_floor(a, factor=1):
     """ functor for floor with factor factor """
-    return int(factor * Decimal(math.floor(Decimal(a) / factor)))
+    return factor * Decimal(math.floor(Decimal(a) / factor))
 
 
 def func_even(a):
     """ functor for rounding up to next even integer """
-    return func_ceil(a, 2)
+    return int(func_ceil(a, 2))
 
 
 def func_odd(a):
     """ functor for rounding up to next odd integer """
     if a % 2 == 1:
         return a
-    return func_ceil(a, 2) + 1
+    return int(func_ceil(a, 2)) + 1
 
 
 def func_round(a, places=0):

--- a/transformer/transforms/number/spreadsheet_formula_test.py
+++ b/transformer/transforms/number/spreadsheet_formula_test.py
@@ -51,6 +51,10 @@ class TestNumberSpreadsheetStyleFormulaTransform(unittest.TestCase):
             'MEDIAN(50, 1.5, 10)',
             'MEDIAN(50, 1.5)',
             'GEOMEAN(50, 1.5, 10)',
+            'CEILING(-2.5)',
+            'CEILING(-2.5, .25)',
+            'FLOOR(4.3)',
+            'FLOOR(-2.5, .25)',
         ]
         for operation in operations:
             transformed = self.transform(operation)
@@ -60,10 +64,6 @@ class TestNumberSpreadsheetStyleFormulaTransform(unittest.TestCase):
 
     def test_int_output(self):
         operations = [
-            'CEILING(-2.5)',
-            'CEILING(-2.5, .25)',
-            'FLOOR(4.3)',
-            'FLOOR(-2.5, .25)',
             'EVEN(-4.3)',
             'INT(4.5)',
             'ODD(4.3)',


### PR DESCRIPTION
Decimal objects should be returned when a non-integer factor is provided.