### PR TITLE
Strip spaces to prevent syntax error

### DIFF
--- a/transformer/transforms/number/spreadsheet_formula.py
+++ b/transformer/transforms/number/spreadsheet_formula.py
@@ -136,6 +136,8 @@ def evaluate(formula, functions=None, operators=None):
         functions = get_default_functions()
     if operators is None:
         operators = get_default_operators()
+    
+    formula = formula.strip()
 
     # first, parse the formula into reverse polish notation
     try:

--- a/transformer/transforms/number/spreadsheet_formula_test.py
+++ b/transformer/transforms/number/spreadsheet_formula_test.py
@@ -76,6 +76,12 @@ class TestNumberSpreadsheetStyleFormulaTransform(unittest.TestCase):
             self.assertIsInstance(
                 transformed, (int, long), '%s: %r is not an instance of int.' % (operation, transformed)
             )
+    
+    def test_strip(self):
+        transformer = spreadsheet_formula.NumberSpreadsheetStyleFormulaTransform()
+        transformer.transform('IF(AND("Mon" = "Sun", 00<20), "today at 8pm", "2am") ')
+        transformer.transform(' IF(AND("Mon" = "Sun", 00<20), "today at 8pm", "2am")')
+        transformer.transform(' IF(AND("Mon" = "Sun", 00<20), "today at 8pm", "2am") ')
 
     def test_spreadsheet_formula(self):
         transformer = spreadsheet_formula.NumberSpreadsheetStyleFormulaTransform()


### PR DESCRIPTION
Without it, a trailing space will cause a syntax error:

```
Traceback (most recent call last):
  File "/Users/fokkezb/git/transformer/transformer/transforms/number/spreadsheet_formula_test.py", line 82, in test_trim
    transformer.transform('IF(AND("Mon" = "Sun", 00<20), "today at 8pm", "2am") ')
  File "/Users/fokkezb/git/transformer/transformer/transforms/number/spreadsheet_formula.py", line 437, in transform
    return evaluate(formula)
  File "/Users/fokkezb/git/transformer/transformer/transforms/number/spreadsheet_formula.py", line 144, in evaluate
    raise Exception('Syntax Error'.format(e))
Exception: Syntax Error
```