### PR TITLE
Include first match if Extract Pattern regex has no subgroups

### DIFF
--- a/transformer/transforms/string/pattern_extract.py
+++ b/transformer/transforms/string/pattern_extract.py
@@ -31,8 +31,13 @@ class StringPatternExtractTransform(BaseTransform):
             '_end': match.end(),
         })
         
-        for idx, val in enumerate(match.groups()):
+        groups = match.groups()
+        for idx, val in enumerate(groups):
             result[idx] = val
+
+        if len(groups) < 1:
+            result[0] = str_input[match.start():match.end()]
+
         
         result.update(match.groupdict())
 

--- a/transformer/transforms/string/pattern_extract_test.py
+++ b/transformer/transforms/string/pattern_extract_test.py
@@ -15,3 +15,14 @@ class TestStringPatternExtractTransform(unittest.TestCase):
             "Hello foo bar folks and another foo I will not catch", pattern),
             {0: 'oo', 1: ' bar', 2: 'a', '_end': 13, '_start': 6, '_matched': True, 'named': 'a'}
         )
+
+    def test_pattern_extract_without_match_groups(self):
+        transformer = pattern_extract.StringPatternExtractTransform()
+        pattern = "foo"
+        self.assertEqual(transformer.transform("", pattern), {'_matched': False})
+        self.assertEqual(transformer.transform(None, pattern), {'_matched': False})
+        self.assertEqual(transformer.transform(
+            "Hello foo bar folks and another foo I will not catch", pattern),
+            {0: 'foo', '_matched': True, "_start": 6, "_end": 9}
+        )
+


### PR DESCRIPTION
`match.groups()` only returns subgroups from the regex.  In support we've seen multiple cases where a regex doesn't have a subgroup in it and so the actual value of the match isn't returned.  To get that value you need to use a math step to subtract the `_end` from the `_start` and then use a truncate step to strip it out.  That's 3 steps to actually extract the pattern unless you _really_ understand python's regex package.

In this if `match.groups()` doesn't return anything, we return input string sliced with the start and end at key `0` for consistency.

Removes need for:
- Rover Note: https://zapier.com/rover/app/ZapierFormatterDevAPI/notes/2880#note-2880
- Help Section https://zapier.com/help/formatter/#the-quotextract-patternquot-transform-isn39t-giving-me-text-output

Shouldn't break anything. Only case I can think of is if a person has`{{ stepID_0 }}` in a template using a regex with optional subgroups that might return a match but not the optional subgroup and they are actually relying on the missing subgroup to cause the Zap to error. In that exact case their Zap will now 
 finish instead of erroring out...but that's so edge-case-y and unlikely I almost feel silly typing it.