### PR TITLE
Add "All (as separate fields)" option to Split

### DIFF
--- a/transformer/transforms/string/split.py
+++ b/transformer/transforms/string/split.py
@@ -26,6 +26,9 @@ class StringSplitTransform(BaseTransform):
         if index == 'all':
             return segments
 
+        if index == 'fields':
+            return { "Item {0}".format(i + 1): s for i, s in enumerate(segments) }
+
         index = try_parse_number(index, cls=int)
         try:
             return segments[index]
@@ -49,7 +52,7 @@ class StringSplitTransform(BaseTransform):
                 'key': 'index',
                 'label': 'Segment Index',
                 'help_text': 'Segment of text to return after splitting. (Default: First)',
-                'choices': '0|First,1|Second,-1|Last,-2|Second to Last,all|All',
+                'choices': '0|First,1|Second,-1|Last,-2|Second to Last,all|All (as line items),fields|All (as separate fields)',
             },
         ]
 

--- a/transformer/transforms/string/split.py
+++ b/transformer/transforms/string/split.py
@@ -27,7 +27,7 @@ class StringSplitTransform(BaseTransform):
             return segments
 
         if index == 'fields':
-            return { "Item {0}".format(i + 1): s for i, s in enumerate(segments) }
+            return { u'Item {}'.format(i + 1): s for i, s in enumerate(segments) }
 
         index = try_parse_number(index, cls=int)
         try:

--- a/transformer/transforms/string/split_test.py
+++ b/transformer/transforms/string/split_test.py
@@ -39,6 +39,9 @@ class TestStringStripTransform(unittest.TestCase):
             ('a, b, c, d', ', ', 'all', ['a', 'b', 'c', 'd']),
             ('a, b, c, d, ', ', ', 'all', ['a', 'b', 'c', 'd', '']),
 
+            ('a, b, c, d', ', ', 'fields', { 'Item 1': 'a', 'Item 2': 'b', 'Item 3': 'c', 'Item 4': 'd'}),
+            ('a, b, c, d, ', ', ', 'fields', { 'Item 1': 'a', 'Item 2': 'b', 'Item 3': 'c', 'Item 4': 'd', 'Item 5': ''}),
+
             ('hello world', '[:space:]', 0, 'hello'),
             ('hello world', '[:space:]', 1, 'world'),
             ('hello world', '[:space:]', -1, 'world'),
@@ -63,6 +66,7 @@ class TestStringStripTransform(unittest.TestCase):
         transformer = split.StringSplitTransform()
 
         self.assertEqual([['a', 'b'], ['c', 'd']], transformer.transform_many(['a,b', 'c,d'], dict(separator=',', index='all')))
+        self.assertEqual([{'Item 1':'a', 'Item 2': 'b'}, {'Item 1':'c', 'Item 2':'d'}], transformer.transform_many(['a,b', 'c,d'], dict(separator=',', index='fields')))
 
     def test_split_many_empty(self):
         transformer = split.StringSplitTransform()


### PR DESCRIPTION
Addresses this Loki issue: https://zapier.com/rover/app/ZapierFormatterDevAPI/issues/18/

When a customer splits a string but needs to select the parts separately they have to add a step for each result index they need to use.  This results in Zaps with many many extra, tedious, and hard to follow steps.

This PR adds an option to the **Segment Index** field called **All (as separate fields)** that returns a dict of the split so that they can be selected by key.  For example `"apples,oranges,banaynays"` becomes `{"Item 1": "apples", "Item 2": "oranges", "Item 3": "banaynays"}`.  The customer can now select those individually in their Zap instead of re-splitting with a new step for each index they need.

Implementation matches @vivavo 's suggestions in the Loki issue with the following changes:

- The current "All" index is renamed to "All (as line items)" instead of the suggested "All (as an array/list)" to match the terminology used elsewhere
- The keys for the dict returned are "Item N" instead of "Field N".  The user will still be thinking of it as a list so "Item" makes more sense than "Field" even if it's technically now a field on our end.

If line items are passed in to be split (`['a,b', 'c,d']`) they follow the current Formatter convention of returning a list of dicts (`[{'Item 1':'a', 'Item 2': 'b'}, {'Item 1':'c', 'Item 2':'d'}]`).  This is particularly useful behavior for Invoice Zaps.