### PR TITLE
Add Italy to list of available countries

### DIFF
--- a/transformer/transforms/number/phone.py
+++ b/transformer/transforms/number/phone.py
@@ -88,6 +88,7 @@ class PhoneNumberFormattingTransform(BaseTransform):
             'DE': 'Germany',
             'PT': 'Portugal',
             'BR': 'Brazil',
+            'IT': 'Italy'
         }
 
         return [


### PR DESCRIPTION
Added Italy to the list of available countries as I have a user requesting that (https://secure.helpscout.net/conversation/629239508/949647?folderId=1777900)

I couldn't see if there was a separate resource to define the number that matches the County code, if there is and I haven't found it, the number is +39