### PR TITLE
csv.import

### DIFF
--- a/transformer/transforms/util/import_csv.py
+++ b/transformer/transforms/util/import_csv.py
@@ -1,0 +1,49 @@
+from transformer.registry import register
+from transformer.transforms.base import BaseTransform
+import csv
+import urllib2
+
+class UtilImportCSVTransform(BaseTransform):
+
+    category = "util"
+    name = "import_csv"
+    label = "Import CSV File"
+    # Flesh this out to describe more functions
+    help_text = (
+        "Import a csv file from a public URL or file field from another Zap step"
+        "More on csv files [here] (https://zapier.com/help/formatter/#how-use-line-items-formatterv2)"
+    )
+
+    noun = "CSV"
+    verb = "import"
+
+    def transform(self, csv_url, line_items=true, **kwargs):
+        # Take a file input and output a set of line-item fields, or a big string field
+
+        if not csv_url:
+            return u''
+
+        input_key = "Line-item(s)"
+        url = csv_url
+        response1 = urllib2.urlopen(url)
+        response2 = urllib2.urlopen(url)
+        response3 = urllib2.urlopen(url)
+        header = csv.Sniffer().has_header(response2.read(1024))
+        dialect = csv.Sniffer().sniff(response3.read(1024))
+        this_line_item = []
+        csvreader = csv.DictReader(response1, dialect=dialect)
+        for row in csvreader:
+            this_line_item.append(row)
+        return {input_key: this_line_item}
+
+    def fields(self, *args, **kwargs):
+        return [
+            {
+                "type": "boolean",
+                "required": False,
+                "key": "line_items",
+                "label": "Line-items",
+                "help_text": "By default, the csv will be imported into line-item fields. Select No to import into a text field instead."
+            }
+        ]
+register(UtilImportCSVTransform())

--- a/transformer/transforms/util/import_csv.py
+++ b/transformer/transforms/util/import_csv.py
@@ -1,7 +1,8 @@
 from transformer.registry import register
 from transformer.transforms.base import BaseTransform
 import csv
-import urllib2
+import urllib
+import tempfile
 
 class UtilImportCSVTransform(BaseTransform):
 
@@ -17,24 +18,44 @@ class UtilImportCSVTransform(BaseTransform):
     noun = "CSV"
     verb = "import"
 
-    def transform(self, csv_url, line_items=true, **kwargs):
+
+    def transform(self, csv_url, options=None, **kwargs):
         # Take a file input and output a set of line-item fields, or a big string field
 
         if not csv_url:
             return u''
 
+        if options is None:
+            options = {}
+        else:
+            string_output = options.get('line_items')
+
         input_key = "Line-item(s)"
         url = csv_url
-        response1 = urllib2.urlopen(url)
-        response2 = urllib2.urlopen(url)
-        response3 = urllib2.urlopen(url)
-        header = csv.Sniffer().has_header(response2.read(1024))
-        dialect = csv.Sniffer().sniff(response3.read(1024))
+        response = tempfile.NamedTemporaryFile()
+        urllib.urlretrieve(url, response.name)
+        header = csv.Sniffer().has_header(response.read(1024))
+        response.seek(0)
+        dialect = csv.Sniffer().sniff(response.read(1024))
+        response.seek(0)
+
+        output = {input_key: [], "header": header, "dialect": str(dialect)}
         this_line_item = []
-        csvreader = csv.DictReader(response1, dialect=dialect)
-        for row in csvreader:
-            this_line_item.append(row)
-        return {input_key: this_line_item}
+        
+        if header:
+            # we have headers
+            csvreader = csv.DictReader(response, dialect=dialect)
+            for row in csvreader:
+                this_line_item.append(row)
+            output[input_key] = this_line_item
+        else:
+            # we don't have headers, so need some fake LI keys, but need number of fields....
+            csvreader = csv.DictReader(response, dialect=dialect)
+            for row in csvreader:
+                this_line_item.append(row)
+            output[input_key] = this_line_item
+        response.close()
+        return output
 
     def fields(self, *args, **kwargs):
         return [

--- a/transformer/transforms/util/import_csv.py
+++ b/transformer/transforms/util/import_csv.py
@@ -4,17 +4,19 @@ import csv
 import urllib
 import tempfile
 
-MAX_CSV_FILE_SIZE = 500000
+#Approximate size of a 1000 line CSV with 14 columns, some tezt in each
+#This takes ~3-5 seconds to turn into line-items in Zapier, and is still workable in the editor
+#So not arbitrary, but I'm sure it could be tweaked
+MAX_CSV_FILE_SIZE = 150000
 
 class UtilImportCSVTransform(BaseTransform):
 
     category = "util"
     name = "import_csv"
     label = "Import CSV File"
-    # Flesh this out to describe more functions
     help_text = (
         "Import a csv file from a public URL, File field from another Zap step, or entered text. "
-        "Limited to 500k/1000 rows. "
+        "Limited to 150k/1000 rows. "
         "More on using csv files [here] (https://zapier.com/help/formatter/#how-process-csvs-formatter)"
     )
 
@@ -49,9 +51,8 @@ class UtilImportCSVTransform(BaseTransform):
         #check file size
         response.seek(0, 2)
         size = response.tell()
-        size_in_K = size / 1000
         if (size > MAX_CSV_FILE_SIZE):
-            self.raise_exception('CSV Import only supports file sizes < 500K.')
+            self.raise_exception('CSV Import only supports file sizes < 150K.')
 
         # use csv utils to see if there is a header, and get the dialect (format) of the csv
         response.seek(0)
@@ -65,7 +66,7 @@ class UtilImportCSVTransform(BaseTransform):
             input_key = "Line-item(s)"
             if header:
             # we have headers
-                output = {input_key: [], "header": header, "filesize": str(size_in_K) + 'K', "line item output": li_output}
+                output = {input_key: [], "header": header, "line item output": li_output}
                 this_line_item = []
                 csvreader = csv.DictReader(response, dialect=dialect)
                 for row in csvreader:
@@ -86,7 +87,7 @@ class UtilImportCSVTransform(BaseTransform):
         else:
             #output is a big string
             input_key = "CSV Text"
-            output = {input_key: "", "header": header, "filesize": str(size_in_K) + 'K',"line item output": li_output}
+            output = {input_key: "", "header": header,"line item output": li_output}
             output[input_key] = response.read()
 
         response.close()
@@ -99,7 +100,7 @@ class UtilImportCSVTransform(BaseTransform):
                 "required": False,
                 "key": "line_items",
                 "label": "Line-items",
-                "help_text": "By default, the csv will be imported into line-item fields. Select No to import into a text field instead."
+                "help_text": "By default, the csv file will be imported into line-item fields. Select No to import into a text field instead."
             }
 
         ]

--- a/transformer/transforms/util/import_csv.py
+++ b/transformer/transforms/util/import_csv.py
@@ -5,7 +5,7 @@ import urllib
 import tempfile
 import os
 
-MAX_CSV_FILE_SIZE = 25e6
+MAX_CSV_FILE_SIZE = 50000
 
 class UtilImportCSVTransform(BaseTransform):
 
@@ -15,7 +15,7 @@ class UtilImportCSVTransform(BaseTransform):
     # Flesh this out to describe more functions
     help_text = (
         "Import a csv file from a public URL, File field from another Zap step, or entered text. "
-        "Limited to 500k/1000 rows "
+        "Limited to 500k/1000 rows. "
         "More on using csv files [here] (https://zapier.com/help/formatter/#how-process-csvs-formatter)"
     )
 
@@ -30,18 +30,18 @@ class UtilImportCSVTransform(BaseTransform):
             "label": "CSV file",
         }
 
-    def transform(self, csv_url, options=None, **kwargs):
+    def transform(self, csv_url, line_items=None, **kwargs):
         # Take a file input and output a set of line-item fields, or a big string field
 
         if not csv_url:
             return u''
 
-        if options is None:
-            options = {}
+        if line_items is None:
+            li_output = True
         else:
-            string_output = options.get('line_items')
+            li_output = line_items
 
-        input_key = "Line-item(s)"
+
         url = csv_url
         response = tempfile.NamedTemporaryFile()
 
@@ -53,32 +53,45 @@ class UtilImportCSVTransform(BaseTransform):
         size = response.tell()
         size_in_K = size / 1000
 
+        if (size > MAX_CSV_FILE_SIZE):
+            self.raise_exception('CSV Import only supports file sizes < 500K.')
+
+
         response.seek(0)
         header = csv.Sniffer().has_header(response.read())
         response.seek(0)
         dialect = csv.Sniffer().sniff(response.read())
         response.seek(0)
 
-        output = {input_key: [], "header": header, "size": size_in_K}
-        this_line_item = []
-
-        if header:
+        if li_output:
+            # output a line-item
+            input_key = "Line-item(s)"
+            if header:
             # we have headers
-            csvreader = csv.DictReader(response, dialect=dialect)
-            for row in csvreader:
-                this_line_item.append(row)
-            output[input_key] = this_line_item
+                output = {input_key: [], "header": header, "size": str(size_in_K) + 'K', "line item output": li_output}
+                this_line_item = []
+                csvreader = csv.DictReader(response, dialect=dialect)
+                for row in csvreader:
+                    this_line_item.append(row)
+                output[input_key] = this_line_item
+            else:
+                # we don't have headers, so need some fake LI keys, but need number of fields....
+                headerreader = csv.reader(response, dialect=dialect)
+                row1 = headerreader.next()
+                fieldnames = { 'Item {}'.format(i + 1): s for i, s in enumerate(row1)}
+                # now we have field names as Item 1..n - lets hope row #1 has everything it needs
+                response.seek(0)
+                csvreader = csv.DictReader(response, fieldnames=fieldnames, dialect=dialect)
+                for row in csvreader:
+                    this_line_item.append(row)
+                output[input_key] = this_line_item
+
         else:
-            # we don't have headers, so need some fake LI keys, but need number of fields....
-            headerreader = csv.reader(response, dialect=dialect)
-            row1 = headerreader.next()
-            fieldnames = { 'Item {}'.format(i + 1): s for i, s in enumerate(row1)}
-            # now we have field names as Item 1..n - lets hope row #1 has everything it needs
-            response.seek(0)
-            csvreader = csv.DictReader(response, fieldnames=fieldnames, dialect=dialect)
-            for row in csvreader:
-                this_line_item.append(row)
-            output[input_key] = this_line_item
+            #output is a string
+            input_key = "CSV Text"
+            output = {input_key: "", "header": header, "size": str(size_in_K) + 'K',"line item output": li_output}
+            output[input_key] = response.read()
+
         response.close()
         return output
 

--- a/transformer/transforms/util/import_csv.py
+++ b/transformer/transforms/util/import_csv.py
@@ -41,7 +41,7 @@ class UtilImportCSVTransform(BaseTransform):
 
         output = {input_key: [], "header": header, "dialect": str(dialect)}
         this_line_item = []
-        
+
         if header:
             # we have headers
             csvreader = csv.DictReader(response, dialect=dialect)
@@ -50,7 +50,12 @@ class UtilImportCSVTransform(BaseTransform):
             output[input_key] = this_line_item
         else:
             # we don't have headers, so need some fake LI keys, but need number of fields....
-            csvreader = csv.DictReader(response, dialect=dialect)
+            headerreader = csv.reader(response, dialect=dialect)
+            row1 = headerreader.next()
+            fieldnames = { 'Item {}'.format(i + 1): s for i, s in enumerate(row1)}
+            # now we have field names - lets hope row #1 has everything it needs
+            response.seek(0)
+            csvreader = csv.DictReader(response, fieldnames=fieldnames, dialect=dialect)
             for row in csvreader:
                 this_line_item.append(row)
             output[input_key] = this_line_item

--- a/transformer/transforms/util/import_csv.py
+++ b/transformer/transforms/util/import_csv.py
@@ -4,7 +4,7 @@ import csv
 import urllib
 import tempfile
 
-MAX_CSV_FILE_SIZE = 50000
+MAX_CSV_FILE_SIZE = 500000
 
 class UtilImportCSVTransform(BaseTransform):
 

--- a/transformer/transforms/util/import_csv_test.py
+++ b/transformer/transforms/util/import_csv_test.py
@@ -9,8 +9,30 @@ class TestUtilImportCSVTransform(unittest.TestCase):
         self.assertEqual(
         {
             "CSV Text": "\xc3\xb8o,\xc3\xa9e,\xc3\xbcu\n1,2,3\n4,5,6\n8,9,10\n",
-            "filesize": "0K",
             "header": True,
             "line item output": False
         },
         transformer.transform('https://drive.google.com/uc?export=download&id=1R_Pr0qaIUUVNO8c0oHoFnNtJl3el86xw', False))
+        self.assertEqual(
+        {
+            "Line-item(s)": [{"\xc3\xb8o":"1","\xc3\xa9e":"2","\xc3\xbcu":"3"},
+            {"\xc3\xb8o":"4","\xc3\xa9e":"5","\xc3\xbcu":"6"},
+            {"\xc3\xb8o":"8","\xc3\xa9e":"9","\xc3\xbcu":"10"}],
+            "header": True,
+            "line item output": True
+        },
+        transformer.transform('https://drive.google.com/uc?export=download&id=1R_Pr0qaIUUVNO8c0oHoFnNtJl3el86xw', True))
+        self.assertEqual(
+        {
+            "CSV Text": "garbage stuff here.....",
+            "header": True,
+            "line item output": False
+        },
+        transformer.transform('https://drive.google.com/uc?export=download&id=14lvE6KkQzFvbl0bd8DOoW-12aTRUHEQH', False))
+        self.assertEqual(
+        {
+            "Line-item(s)": [],
+            "header": True,
+            "line item output": True
+        },
+        transformer.transform('https://drive.google.com/uc?export=download&id=14lvE6KkQzFvbl0bd8DOoW-12aTRUHEQH', True))

--- a/transformer/transforms/util/import_csv_test.py
+++ b/transformer/transforms/util/import_csv_test.py
@@ -1,0 +1,10 @@
+import unittest
+import import_csv
+
+
+class TestUtilImportCSVTransform(unittest.TestCase):
+
+    def test_import_csv(self):
+        transformer = import_csv.UtilImportCSVTransform()
+
+        #self.assertEqual('', transformer.transform([''], options={'line_item':0}))

--- a/transformer/transforms/util/import_csv_test.py
+++ b/transformer/transforms/util/import_csv_test.py
@@ -6,5 +6,11 @@ class TestUtilImportCSVTransform(unittest.TestCase):
 
     def test_import_csv(self):
         transformer = import_csv.UtilImportCSVTransform()
-
-        #self.assertEqual('', transformer.transform([''], options={'line_item':0}))
+        self.assertEqual(
+        {
+            "CSV Text": "\xc3\xb8o,\xc3\xa9e,\xc3\xbcu\n1,2,3\n4,5,6\n8,9,10\n",
+            "filesize": "0K",
+            "header": True,
+            "line item output": False
+        },
+        transformer.transform('https://drive.google.com/uc?export=download&id=1R_Pr0qaIUUVNO8c0oHoFnNtJl3el86xw', False))


### PR DESCRIPTION
This PR is for to test the viability of a simple csv importer for Formatter. Current functionality takes a URL or hydrated File field and parses a simple CSV (comma delimited, new-line) into line-item fields. (there is an option for importing into a text field, but that is not yet implemented).

It will process files that have both headers and no headers, for those without it uses the line-item element name of "Item n".

Things it needs:

1) Other csv formats (different delimiters)
2) File size checking
3) Other stuff...

Working example of this transform is here, running on my local ngrok:
https://zapier.com/app/editor/43842666/nodes/54320747/sample