### PR TITLE
PR to fix Loki on field values, and verify if Loki on header forcing is doable

### DIFF
--- a/transformer/transforms/util/import_csv.py
+++ b/transformer/transforms/util/import_csv.py
@@ -18,7 +18,7 @@ class UtilImportCSVTransform(BaseTransform):
         "Import a CSV file from a public URL, File field from another Zap step, or entered text.  "
         "Limited to 150k (around 1000 rows).  "
         "Output is a line-item field for each column, and a text field with CSV file contents.  "
-        "When you do your Test Step, you'll only see 10 rows of your CSV, but when your Zap runs all rows will be processed. "
+        "When you do your Test Step, you'll only see 10 rows of your CSV file, but when your Zap runs all rows will be processed. "
         "More on importing csv files [here.](https://zapier.com/help/formatter/#how-import-csv-files-formatter)"
     )
 

--- a/transformer/transforms/util/import_csv.py
+++ b/transformer/transforms/util/import_csv.py
@@ -104,7 +104,7 @@ class UtilImportCSVTransform(BaseTransform):
                 "default": "no",
                 'help_text': (
                     'By default, Import CSV File will try to determine if your file has a header row. '
-                    'If you find in your test step that this did not work (header field will be false), you can force it here by selecting yes.'
+                    'If you find in your Test Step that this did not work (the header field will be False), you can force it here by selecting yes.'
                 ),  # NOQA
             },
         ]

--- a/transformer/transforms/util/import_csv.py
+++ b/transformer/transforms/util/import_csv.py
@@ -69,7 +69,7 @@ class UtilImportCSVTransform(BaseTransform):
                 this_line_item.append(row)
             output["line_items"] = this_line_item
         else:
-            # we don't have headers, so need some fake LI keys, but first need number of fields, so grab the first row....
+            # we don't have headers, so need some line-item labels, but first need number of fields, so grab the first row....
             header_reader = csv.reader(response, dialect=dialect)
             row_1 = header_reader.next()
             if forced_header:
@@ -77,10 +77,9 @@ class UtilImportCSVTransform(BaseTransform):
                 field_names = list(s.format(i + 1) for i, s in enumerate(row_1))
                 output["header"] = 'forced'
             else:
-                # user says that the first row is not a header row, create line item lables item_1...item_n
+                # user says that the first row is not a header row, create field names item_1...item_n which become the line-item labels
                 field_names = list('item_{}'.format(i + 1) for i, s in enumerate(row_1))
                 response.seek(0)
-                # previous version, this put them in reverse order... field_names = { 'item_{}'.format(i + 1): s for i, s in enumerate(row_1)}
             csvreader = csv.DictReader(response, fieldnames=field_names, dialect=dialect)
             for row in csvreader:
                 this_line_item.append(row)

--- a/transformer/transforms/util/import_csv.py
+++ b/transformer/transforms/util/import_csv.py
@@ -72,7 +72,8 @@ class UtilImportCSVTransform(BaseTransform):
             # we don't have headers, so need some fake LI keys, but first need number of fields, so grab the first row....
             header_reader = csv.reader(response, dialect=dialect)
             row_1 = header_reader.next()
-            field_names = { 'item_{}'.format(i + 1): s for i, s in enumerate(row_1)}
+            field_names = list('item_{}'.format(i + 1) for i, s in enumerate(row_1))
+            # previous version, this put them in reverse order... field_names = { 'item_{}'.format(i + 1): s for i, s in enumerate(row_1)}
             # now we have field names as item 1..n - lets hope row #1 has everything it needs
             response.seek(0)
             csvreader = csv.DictReader(response, fieldnames=field_names, dialect=dialect)

--- a/transformer/transforms/util/import_csv.py
+++ b/transformer/transforms/util/import_csv.py
@@ -62,6 +62,7 @@ class UtilImportCSVTransform(BaseTransform):
         output = {"line_items": [],"csv_text": "", "header": header}
         # output line-items
         this_line_item = []
+        forced_header = False
         if header:
             # we have headers
             csv_reader = csv.DictReader(response, dialect=dialect)
@@ -72,10 +73,14 @@ class UtilImportCSVTransform(BaseTransform):
             # we don't have headers, so need some fake LI keys, but first need number of fields, so grab the first row....
             header_reader = csv.reader(response, dialect=dialect)
             row_1 = header_reader.next()
-            field_names = list('item_{}'.format(i + 1) for i, s in enumerate(row_1))
-            # previous version, this put them in reverse order... field_names = { 'item_{}'.format(i + 1): s for i, s in enumerate(row_1)}
-            # now we have field names as item 1..n - lets hope row #1 has everything it needs
-            response.seek(0)
+            if forced_header:
+                # user says that the first row is a header row, lets hope it has everything we need
+                fieldnames = list(s.format(i + 1) for i, s in enumerate(row1))
+            else:
+                # user says that the first row is not a header row, create line item lables item_1...item_n
+                fieldnames = list('item_{}'.format(i + 1) for i, s in enumerate(row1))
+                response.seek(0)
+                # previous version, this put them in reverse order... field_names = { 'item_{}'.format(i + 1): s for i, s in enumerate(row_1)}
             csvreader = csv.DictReader(response, fieldnames=field_names, dialect=dialect)
             for row in csvreader:
                 this_line_item.append(row)

--- a/transformer/transforms/util/import_csv.py
+++ b/transformer/transforms/util/import_csv.py
@@ -102,8 +102,8 @@ class UtilImportCSVTransform(BaseTransform):
                 'label': 'Force First Row as Header Row',
                 "default": "no",
                 'help_text': (
-                    'By default, Import CSV file will try to determine if your file has a header row. '
-                    'If you find in your test step that this magic did not work (header will be false), you can force it here by selecting yes.'
+                    'By default, Import CSV File will try to determine if your file has a header row. '
+                    'If you find in your test step that this did not work (header field will be false), you can force it here by selecting yes.'
                 ),  # NOQA
             },
         ]

--- a/transformer/transforms/util/import_csv.py
+++ b/transformer/transforms/util/import_csv.py
@@ -19,7 +19,7 @@ class UtilImportCSVTransform(BaseTransform):
         "Limited to 150k (around 1000 rows).  "
         "Output is a line-item field for each column, and a text field with CSV file contents.  "
         "When you do your Test Step, you'll only see 10 rows of your CSV file, but when your Zap runs all rows will be processed. "
-        "More on importing csv files [here.](https://zapier.com/help/formatter/#how-import-csv-files-formatter)"
+        "More on importing CSV files [here.](https://zapier.com/help/formatter/#how-import-csv-files-formatter)"
     )
 
     noun = "CSV"

--- a/transformer/transforms/util/import_csv.py
+++ b/transformer/transforms/util/import_csv.py
@@ -18,7 +18,7 @@ class UtilImportCSVTransform(BaseTransform):
         "Import a CSV file from a public URL, File field from another Zap step, or entered text.  "
         "Limited to 150k (around 1000 rows).  "
         "Output is a line-item field for each column, and a text field with CSV file contents.  "
-        "When you do your Test Step, you'll only see 10 rows of your CSV file, but when your Zap runs all rows will be processed. "
+        "When you do your Test Step, you'll only see the first 10 rows of your CSV file, but when your Zap runs all rows will be processed. "
         "More on importing CSV files [here.](https://zapier.com/help/formatter/#how-import-csv-files-formatter)"
     )
 

--- a/transformer/transforms/util/import_csv.py
+++ b/transformer/transforms/util/import_csv.py
@@ -18,6 +18,7 @@ class UtilImportCSVTransform(BaseTransform):
         "Import a CSV file from a public URL, File field from another Zap step, or entered text.  "
         "Limited to 150k (around 1000 rows).  "
         "Output is a line-item field for each column, and a text field with CSV file contents.  "
+        "When you do your Test Step, you'll only see 10 rows of your CSV, but when your Zap runs all rows will be processed. "
         "More on importing csv files [here.](https://zapier.com/help/formatter/#how-import-csv-files-formatter)"
     )
 

--- a/transformer/transforms/util/import_csv_test.py
+++ b/transformer/transforms/util/import_csv_test.py
@@ -16,7 +16,7 @@ class TestUtilImportCSVTransform(unittest.TestCase):
             "header": True
 
         },
-        transformer.transform('https://drive.google.com/uc?export=download&id=1R_Pr0qaIUUVNO8c0oHoFnNtJl3el86xw'))
+        transformer.transform('https://drive.google.com/uc?export=download&id=1R_Pr0qaIUUVNO8c0oHoFnNtJl3el86xw',True))
         # UTF-8 - line-item_
         # UTF-8 - no csv, just text
         self.assertEqual(
@@ -25,36 +25,71 @@ class TestUtilImportCSVTransform(unittest.TestCase):
             "line_items":[],
             "header": True
         },
-        transformer.transform('https://drive.google.com/uc?export=download&id=14lvE6KkQzFvbl0bd8DOoW-12aTRUHEQH'))
+        transformer.transform('https://drive.google.com/uc?export=download&id=14lvE6KkQzFvbl0bd8DOoW-12aTRUHEQH',True))
         # no headers - values missing, but all delimited
         self.assertEqual(
         {
         "csv_text": "1,2,3,4,5\n5,6,7,,8\n9,,11,,12\n,,14,15,16",
-        "line_items": [{
+        "line_items": [
+      {
         "item_1": "1",
         "item_2": "2",
         "item_3": "3",
         "item_4": "4",
         "item_5": "5"
-      }, {
+      },
+      {
         "item_1": "5",
         "item_2": "6",
         "item_3": "7",
         "item_4": "",
         "item_5": "8"
-      }, {
+      },
+      {
         "item_1": "9",
         "item_2": "",
         "item_3": "11",
         "item_4": "",
         "item_5": "12"
-      }, {
+      },
+      {
         "item_1": "",
         "item_2": "",
         "item_3": "14",
         "item_4": "15",
         "item_5": "16"
-      }],
-    "header": False,
-  },
-    transformer.transform('https://drive.google.com/uc?export=download&id=1I-t5L1KiDu4RDZCFTW2ydzJNwlfwm4Ld'))
+      }
+      ],
+        "header": False,
+        },
+        transformer.transform('https://drive.google.com/uc?export=download&id=1I-t5L1KiDu4RDZCFTW2ydzJNwlfwm4Ld',False))
+        # forced_header headers - values missing, but all delimited
+        self.assertEqual(
+        {
+        "csv_text": "1,2,3,4,5\n5,6,7,,8\n9,,11,,12\n,,14,15,16",
+        "line_items": [
+        {
+        "1": "5",
+        "2": "6",
+        "3": "7",
+        "4": "",
+        "5": "8"
+        },
+        {
+        "1": "9",
+        "2": "",
+        "3": "11",
+        "4": "",
+        "5": "12"
+        },
+        {
+        "1": "",
+        "2": "",
+        "3": "14",
+        "4": "15",
+        "5": "16"
+      }
+      ],
+      "header": "forced",
+      },
+      transformer.transform('https://drive.google.com/uc?export=download&id=1I-t5L1KiDu4RDZCFTW2ydzJNwlfwm4Ld',True))

--- a/transformer/transforms/util/import_csv_test.py
+++ b/transformer/transforms/util/import_csv_test.py
@@ -31,29 +31,29 @@ class TestUtilImportCSVTransform(unittest.TestCase):
         {
         "csv_text": "1,2,3,4,5\n5,6,7,,8\n9,,11,,12\n,,14,15,16",
         "line_items": [{
-        "item_4": "1",
-        "item_5": "2",
-        "item_2": "3",
-        "item_3": "4",
-        "item_1": "5"
+        "item_1": "1",
+        "item_2": "2",
+        "item_3": "3",
+        "item_4": "4",
+        "item_5": "5"
       }, {
-        "item_4": "5",
-        "item_5": "6",
-        "item_2": "7",
-        "item_3": "",
-        "item_1": "8"
-      }, {
-        "item_4": "9",
-        "item_5": "",
-        "item_2": "11",
-        "item_3": "",
-        "item_1": "12"
-      }, {
+        "item_1": "5",
+        "item_2": "6",
+        "item_3": "7",
         "item_4": "",
-        "item_5": "",
-        "item_2": "14",
-        "item_3": "15",
-        "item_1": "16"
+        "item_5": "8"
+      }, {
+        "item_1": "9",
+        "item_2": "",
+        "item_3": "11",
+        "item_4": "",
+        "item_5": "12"
+      }, {
+        "item_1": "",
+        "item_2": "",
+        "item_3": "14",
+        "item_4": "15",
+        "item_5": "16"
       }],
     "header": False,
   },


### PR DESCRIPTION
User reported this bug with line-item labels, where labels were in n..1 vs 1..n order when there was no header:

https://admin.zapier.com/rover/app/ZapierFormatterDevAPI/issues/168/

Turns out that this CSV the user had did have headers, but the python csv library could not parse it. So, added this FR to this PR, as this looks to be a common issue with header rows that look like the column data.

https://admin.zapier.com/rover/app/ZapierFormatterDevAPI/issues/169/

added new option here for forcing first row as header:
![](https://zappy.zapier.com/2068CC70-90A4-464C-A7D2-B2CFA3240684.png)

Zap to see this new function - Step 4: https://zapier.com/app/editor/43842666/nodes/57479190/fields

Added user's CSV to Test Matrix, and ran through all tests again with both yes/no as header forced:
https://zapier.quip.com/NojPA3IzQErf/Formatter-CSV-Import-Testing#SSAACA62mX0