### PR TITLE
Line items to separate fields

### DIFF
--- a/transformer/registry.py
+++ b/transformer/registry.py
@@ -15,7 +15,8 @@ def lookup(name, category=""):
     return None
 
 def get_all(category=""):
-    return [v for k, v in __GLOBAL_REGISTRY.iteritems() if not category or category == v.category]
+    exclude_transforms = ["util.lineitem_to_string"]
+    return [v for k, v in __GLOBAL_REGISTRY.iteritems() if not category or category == v.category and not k in exclude_transforms]
 
 def make_registry():
     import transformer.transforms # NOQA

--- a/transformer/registry.py
+++ b/transformer/registry.py
@@ -15,8 +15,8 @@ def lookup(name, category=""):
     return None
 
 def get_all(category=""):
-    exclude_transforms = ["util.lineitem_to_string"]
-    return [v for k, v in __GLOBAL_REGISTRY.iteritems() if not category or category == v.category and not k in exclude_transforms]
+    legacy_transforms = ["util.lineitem_to_string"]
+    return [v for k, v in __GLOBAL_REGISTRY.iteritems() if not category or category == v.category and not k in legacy_transforms]
 
 def make_registry():
     import transformer.transforms # NOQA

--- a/transformer/transforms/util/lineitem_to_string_v2.py
+++ b/transformer/transforms/util/lineitem_to_string_v2.py
@@ -9,7 +9,8 @@ class UtilLineItemToStringV2Transform(BaseTransform):
     name = 'lineitem_to_string_v2'
     label = 'Line-item to Text'
     help_text = (
-        'Convert a line-item to delimited text. [a,b,c,d] becomes \'a,b,c,d\'. More on line-items '
+        'Convert a line-item to delimited text. [a,b,c,d] becomes \'a,b,c,d\'. Also returns '
+        ' each element of the line-item as a separate field. More on line-items '
         '[here](https://zapier.com/help/formatter/#how-use-line-items-formatter).'
     )
 
@@ -22,13 +23,20 @@ class UtilLineItemToStringV2Transform(BaseTransform):
         accepting list inputs which we use to perform the choose operation.
 
         """
+        
+        output = {}
+        
+        #Perform main function of Line item to string:
 
         if not inputs:
-            return u''
+            output["text_output"] = ''
+            return output
 
         #update for Loki issue, return string is only one element
         if not isinstance(inputs, list):
-            return inputs
+            output["text_output"] = inputs
+            output["item 1"] = inputs
+            return output
 
         if options is None:
             options = {}
@@ -36,11 +44,18 @@ class UtilLineItemToStringV2Transform(BaseTransform):
         separator = expand_special_chargroups(options.get('separator'))
 
         if separator:
-            segments = separator.join(inputs)
+            text_ouput = separator.join(inputs)
         else:
-            segments = ','.join(inputs)
+            text_ouput = ','.join(inputs)
 
-        return segments
+        output["text_output"] = text_ouput
+
+        #Create Separate Fields
+        
+        for i, v in enumerate(inputs):
+            output["item "+str(i+1)] = v
+            
+        return output
 
 
     def fields(self, *args, **kwargs):

--- a/transformer/transforms/util/lineitem_to_string_v2.py
+++ b/transformer/transforms/util/lineitem_to_string_v2.py
@@ -29,13 +29,13 @@ class UtilLineItemToStringV2Transform(BaseTransform):
         # Perform main function of Line item to string:
 
         if not inputs:
-            output["text_output"] = ""
+            output["text"] = ""
             output["item 1"] = ""
             return output
 
         # update for Loki issue, return string is only one element
         if not isinstance(inputs, list):
-            output["text_output"] = inputs
+            output["text"] = inputs
             output["item 1"] = inputs
             return output
 
@@ -49,7 +49,7 @@ class UtilLineItemToStringV2Transform(BaseTransform):
         else:
             text_ouput = ",".join(inputs)
 
-        output["text_output"] = text_ouput
+        output["text"] = text_ouput
 
         # Create Separate Fields
 

--- a/transformer/transforms/util/lineitem_to_string_v2.py
+++ b/transformer/transforms/util/lineitem_to_string_v2.py
@@ -31,12 +31,14 @@ class UtilLineItemToStringV2Transform(BaseTransform):
         if not inputs:
             output["text"] = ""
             output["item_1"] = ""
+            output["item_last"] = ""
             return output
 
         # update for Loki issue, return string is only one element
         if not isinstance(inputs, list):
             output["text"] = inputs
             output["item_1"] = inputs
+            output["item_last"] = inputs
             return output
 
         if options is None:
@@ -55,6 +57,7 @@ class UtilLineItemToStringV2Transform(BaseTransform):
 
         for i, v in enumerate(inputs):
             output["item_" + str(i + 1)] = v
+            output["item_last"] = v
 
         return output
 

--- a/transformer/transforms/util/lineitem_to_string_v2.py
+++ b/transformer/transforms/util/lineitem_to_string_v2.py
@@ -5,17 +5,17 @@ from transformer.util import expand_special_chargroups
 
 class UtilLineItemToStringV2Transform(BaseTransform):
 
-    category = 'util'
-    name = 'lineitem_to_string_v2'
-    label = 'Line-item to Text'
+    category = "util"
+    name = "lineitem_to_string_v2"
+    label = "Line-item to Text"
     help_text = (
-        'Convert a line-item to delimited text. [a,b,c,d] becomes \'a,b,c,d\'. Also returns '
-        ' each element of the line-item as a separate field. More on line-items '
-        '[here](https://zapier.com/help/formatter/#how-use-line-items-formatter).'
+        "Convert a line-item to delimited text. [a,b,c,d] becomes 'a,b,c,d'. Also returns "
+        " each element of the line-item as a separate field. More on line-items "
+        "[here](https://zapier.com/help/formatter/#how-use-line-items-formatter)."
     )
 
-    noun = 'Line-Item'
-    verb = 'Convert'
+    noun = "Line-Item"
+    verb = "Convert"
 
     def transform_many(self, inputs, options=None, **kwargs):
         """
@@ -23,16 +23,16 @@ class UtilLineItemToStringV2Transform(BaseTransform):
         accepting list inputs which we use to perform the choose operation.
 
         """
-        
+
         output = {}
-        
-        #Perform main function of Line item to string:
+
+        # Perform main function of Line item to string:
 
         if not inputs:
-            output["text_output"] = ''
+            output["text_output"] = ""
             return output
 
-        #update for Loki issue, return string is only one element
+        # update for Loki issue, return string is only one element
         if not isinstance(inputs, list):
             output["text_output"] = inputs
             output["item 1"] = inputs
@@ -41,35 +41,34 @@ class UtilLineItemToStringV2Transform(BaseTransform):
         if options is None:
             options = {}
 
-        separator = expand_special_chargroups(options.get('separator'))
+        separator = expand_special_chargroups(options.get("separator"))
 
         if separator:
             text_ouput = separator.join(inputs)
         else:
-            text_ouput = ','.join(inputs)
+            text_ouput = ",".join(inputs)
 
         output["text_output"] = text_ouput
 
-        #Create Separate Fields
-        
-        for i, v in enumerate(inputs):
-            output["item "+str(i+1)] = v
-            
-        return output
+        # Create Separate Fields
 
+        for i, v in enumerate(inputs):
+            output["item " + str(i + 1)] = v
+
+        return output
 
     def fields(self, *args, **kwargs):
         return [
             {
-                'type': 'unicode',
-                'required': False,
-                'key': 'separator',
-                'label': 'Separator',
-                'help_text': (
-                    'Character(s) to delimit text with. (Default: \',\') '
-                    'For supported special characters, see: https://zapier.com/help/formatter/#special-characters)'
+                "type": "unicode",
+                "required": False,
+                "key": "separator",
+                "label": "Separator",
+                "help_text": (
+                    "Character(s) to delimit text with. (Default: ',') "
+                    "For supported special characters, see: https://zapier.com/help/formatter/#special-characters)"
                 ),  # NOQA
-            },
+            }
         ]
 
 

--- a/transformer/transforms/util/lineitem_to_string_v2.py
+++ b/transformer/transforms/util/lineitem_to_string_v2.py
@@ -54,7 +54,7 @@ class UtilLineItemToStringV2Transform(BaseTransform):
         # Create Separate Fields
 
         for i, v in enumerate(inputs):
-            output["item " + str(i + 1)] = v
+            output["item_" + str(i + 1)] = v
 
         return output
 

--- a/transformer/transforms/util/lineitem_to_string_v2.py
+++ b/transformer/transforms/util/lineitem_to_string_v2.py
@@ -30,13 +30,13 @@ class UtilLineItemToStringV2Transform(BaseTransform):
 
         if not inputs:
             output["text"] = ""
-            output["item 1"] = ""
+            output["item_1"] = ""
             return output
 
         # update for Loki issue, return string is only one element
         if not isinstance(inputs, list):
             output["text"] = inputs
-            output["item 1"] = inputs
+            output["item_1"] = inputs
             return output
 
         if options is None:

--- a/transformer/transforms/util/lineitem_to_string_v2.py
+++ b/transformer/transforms/util/lineitem_to_string_v2.py
@@ -30,6 +30,7 @@ class UtilLineItemToStringV2Transform(BaseTransform):
 
         if not inputs:
             output["text_output"] = ""
+            output["item 1"] = ""
             return output
 
         # update for Loki issue, return string is only one element

--- a/transformer/transforms/util/lineitem_to_string_v2.py
+++ b/transformer/transforms/util/lineitem_to_string_v2.py
@@ -1,0 +1,61 @@
+from transformer.registry import register
+from transformer.transforms.base import BaseTransform
+from transformer.util import expand_special_chargroups
+
+
+class UtilLineItemToStringV2Transform(BaseTransform):
+
+    category = 'util'
+    name = 'lineitem_to_string_v2'
+    label = 'Line-item to Text'
+    help_text = (
+        'Convert a line-item to delimited text. [a,b,c,d] becomes \'a,b,c,d\'. More on line-items '
+        '[here](https://zapier.com/help/formatter/#how-use-line-items-formatter).'
+    )
+
+    noun = 'Line-Item'
+    verb = 'Convert'
+
+    def transform_many(self, inputs, options=None, **kwargs):
+        """
+        Override the standard behavior of the transform_many by only
+        accepting list inputs which we use to perform the choose operation.
+
+        """
+
+        if not inputs:
+            return u''
+
+        #update for Loki issue, return string is only one element
+        if not isinstance(inputs, list):
+            return inputs
+
+        if options is None:
+            options = {}
+
+        separator = expand_special_chargroups(options.get('separator'))
+
+        if separator:
+            segments = separator.join(inputs)
+        else:
+            segments = ','.join(inputs)
+
+        return segments
+
+
+    def fields(self, *args, **kwargs):
+        return [
+            {
+                'type': 'unicode',
+                'required': False,
+                'key': 'separator',
+                'label': 'Separator',
+                'help_text': (
+                    'Character(s) to delimit text with. (Default: \',\') '
+                    'For supported special characters, see: https://zapier.com/help/formatter/#special-characters)'
+                ),  # NOQA
+            },
+        ]
+
+
+register(UtilLineItemToStringV2Transform())

--- a/transformer/transforms/util/lineitem_to_string_v2_test.py
+++ b/transformer/transforms/util/lineitem_to_string_v2_test.py
@@ -3,39 +3,113 @@ import lineitem_to_string_v2
 
 
 class TestUtilLineItemToStringV2Transform(unittest.TestCase):
-
     def test_lineitem_to_string_v2_empty(self):
         transformer = lineitem_to_string_v2.UtilLineItemToStringV2Transform()
 
-        self.assertEqual('', transformer.transform_many([], options={'separator':','}))
-        self.assertEqual('', transformer.transform_many([''], options={'separator':','}))
+        self.assertEqual(
+            {"text_output": "", "item 1": ""},
+            transformer.transform_many([], options={"separator": ","}),
+        )
+        self.assertEqual(
+            {"text_output": "", "item 1": ""},
+            transformer.transform_many([""], options={"separator": ","}),
+        )
+        self.assertEqual(
+            {"text_output": "", "item 1": ""}, transformer.transform_many("")
+        )
 
     def test_lineitem_to_string_v2_many_empty(self):
         transformer = lineitem_to_string_v2.UtilLineItemToStringV2Transform()
 
-        self.assertEqual(',c,d', transformer.transform_many(['', 'c', 'd'], options={'separator':','}))
-        self.assertEqual(',,c,d', transformer.transform_many(['', '', 'c,d'], options={'separator':','}))
-        self.assertEqual(',', transformer.transform_many(['', ''], options={'separator':','}))
-        self.assertEqual('c,d,', transformer.transform_many(['c', 'd', ''], options={'separator':','}))
-        self.assertEqual(',,c,d', transformer.transform_many(['', '', 'c,d'], options={'separator':','}))
-        self.assertEqual(',', transformer.transform_many(['', ''], options={'separator':','}))
+        self.assertEqual(
+            {"text_output": ",c,d", "item 1": "", "item 2": "c", "item 3": "d"},
+            transformer.transform_many(["", "c", "d"], options={"separator": ","}),
+        )
+        self.assertEqual(
+            {"text_output": ",,c,d", "item 1": "", "item 2": "", "item 3": "c,d"},
+            transformer.transform_many(["", "", "c,d"], options={"separator": ","}),
+        )
+        self.assertEqual(
+            {"text_output": ",", "item 1": "", "item 2": ""},
+            transformer.transform_many(["", ""], options={"separator": ","}),
+        )
+        self.assertEqual(
+            {"text_output": "c,d,", "item 1": "c", "item 2": "d", "item 3": ""},
+            transformer.transform_many(["c", "d", ""], options={"separator": ","}),
+        )
 
     def test_lineitem_to_string_v2_one(self):
         transformer = lineitem_to_string_v2.UtilLineItemToStringV2Transform()
-        self.assertEqual('a', transformer.transform_many(['a'], options={'separator':','}))
+        self.assertEqual(
+            {"text_output": "a", "item 1": "a"},
+            transformer.transform_many(["a"], options={"separator": ","}),
+        )
 
     def test_lineitem_to_string_v2_many(self):
         transformer = lineitem_to_string_v2.UtilLineItemToStringV2Transform()
-        self.assertEqual('a,b,c,d', transformer.transform_many(['a,b', 'c,d'], options={'separator':','}))
-        self.assertEqual('a,b,c,d', transformer.transform_many(['a', 'b', 'c', 'd'], options={'separator':','}))
-        self.assertEqual('a,b,c,d', transformer.transform_many(['a,b,c,d'], options={'separator':','}))
+        self.assertEqual(
+            {"text_output": "a,b,c,d", "item 1": "a,b", "item 2": "c,d"},
+            transformer.transform_many(["a,b", "c,d"], options={"separator": ","}),
+        )
+        self.assertEqual(
+            {
+                "text_output": "a,b,c,d",
+                "item 1": "a",
+                "item 2": "b",
+                "item 3": "c",
+                "item 4": "d",
+            },
+            transformer.transform_many(
+                ["a", "b", "c", "d"], options={"separator": ","}
+            ),
+        )
+        self.assertEqual(
+            {"text_output": "a,b,c,d", "item 1": "a,b,c,d"},
+            transformer.transform_many(["a,b,c,d"], options={"separator": ","}),
+        )
 
     def test_lineitem_to_string_v2_other_separator(self):
         transformer = lineitem_to_string_v2.UtilLineItemToStringV2Transform()
-        self.assertEqual('a b c d', transformer.transform_many(['a', 'b', 'c', 'd'], options={'separator':'[:space:]'}))
-        self.assertEqual('a b c d', transformer.transform_many(['a', 'b', 'c', 'd'], options={'separator':'[:s:]'}))
-        self.assertEqual('a;b;c;d', transformer.transform_many(['a', 'b', 'c', 'd'], options={'separator':';'}))
+        self.assertEqual(
+            {
+                "text_output": "a b c d",
+                "item 1": "a",
+                "item 2": "b",
+                "item 3": "c",
+                "item 4": "d",
+            },
+            transformer.transform_many(
+                ["a", "b", "c", "d"], options={"separator": "[:space:]"}
+            ),
+        )
+        self.assertEqual(
+            {
+                "text_output": "a b c d",
+                "item 1": "a",
+                "item 2": "b",
+                "item 3": "c",
+                "item 4": "d",
+            },
+            transformer.transform_many(
+                ["a", "b", "c", "d"], options={"separator": "[:s:]"}
+            ),
+        )
+        self.assertEqual(
+            {
+                "text_output": "a;b;c;d",
+                "item 1": "a",
+                "item 2": "b",
+                "item 3": "c",
+                "item 4": "d",
+            },
+            transformer.transform_many(
+                ["a", "b", "c", "d"], options={"separator": ";"}
+            ),
+        )
 
     def test_lineitem_to_string_v2_nolineitem(self):
         transformer = lineitem_to_string_v2.UtilLineItemToStringV2Transform()
-        self.assertEqual('abcd', transformer.transform_many('abcd', options={'separator':'[:space:]'}))
+        self.assertEqual(
+            {"text_output": "abcd", "item 1": "abcd"},
+            transformer.transform_many("abcd", options={"separator": "[:space:]"}),
+        )

--- a/transformer/transforms/util/lineitem_to_string_v2_test.py
+++ b/transformer/transforms/util/lineitem_to_string_v2_test.py
@@ -1,0 +1,41 @@
+import unittest
+import lineitem_to_string_v2
+
+
+class TestUtilLineItemToStringV2Transform(unittest.TestCase):
+
+    def test_lineitem_to_string_v2_empty(self):
+        transformer = lineitem_to_string_v2.UtilLineItemToStringV2Transform()
+
+        self.assertEqual('', transformer.transform_many([], options={'separator':','}))
+        self.assertEqual('', transformer.transform_many([''], options={'separator':','}))
+
+    def test_lineitem_to_string_v2_many_empty(self):
+        transformer = lineitem_to_string_v2.UtilLineItemToStringV2Transform()
+
+        self.assertEqual(',c,d', transformer.transform_many(['', 'c', 'd'], options={'separator':','}))
+        self.assertEqual(',,c,d', transformer.transform_many(['', '', 'c,d'], options={'separator':','}))
+        self.assertEqual(',', transformer.transform_many(['', ''], options={'separator':','}))
+        self.assertEqual('c,d,', transformer.transform_many(['c', 'd', ''], options={'separator':','}))
+        self.assertEqual(',,c,d', transformer.transform_many(['', '', 'c,d'], options={'separator':','}))
+        self.assertEqual(',', transformer.transform_many(['', ''], options={'separator':','}))
+
+    def test_lineitem_to_string_v2_one(self):
+        transformer = lineitem_to_string_v2.UtilLineItemToStringV2Transform()
+        self.assertEqual('a', transformer.transform_many(['a'], options={'separator':','}))
+
+    def test_lineitem_to_string_v2_many(self):
+        transformer = lineitem_to_string_v2.UtilLineItemToStringV2Transform()
+        self.assertEqual('a,b,c,d', transformer.transform_many(['a,b', 'c,d'], options={'separator':','}))
+        self.assertEqual('a,b,c,d', transformer.transform_many(['a', 'b', 'c', 'd'], options={'separator':','}))
+        self.assertEqual('a,b,c,d', transformer.transform_many(['a,b,c,d'], options={'separator':','}))
+
+    def test_lineitem_to_string_v2_other_separator(self):
+        transformer = lineitem_to_string_v2.UtilLineItemToStringV2Transform()
+        self.assertEqual('a b c d', transformer.transform_many(['a', 'b', 'c', 'd'], options={'separator':'[:space:]'}))
+        self.assertEqual('a b c d', transformer.transform_many(['a', 'b', 'c', 'd'], options={'separator':'[:s:]'}))
+        self.assertEqual('a;b;c;d', transformer.transform_many(['a', 'b', 'c', 'd'], options={'separator':';'}))
+
+    def test_lineitem_to_string_v2_nolineitem(self):
+        transformer = lineitem_to_string_v2.UtilLineItemToStringV2Transform()
+        self.assertEqual('abcd', transformer.transform_many('abcd', options={'separator':'[:space:]'}))

--- a/transformer/transforms/util/lineitem_to_string_v2_test.py
+++ b/transformer/transforms/util/lineitem_to_string_v2_test.py
@@ -7,48 +7,66 @@ class TestUtilLineItemToStringV2Transform(unittest.TestCase):
         transformer = lineitem_to_string_v2.UtilLineItemToStringV2Transform()
 
         self.assertEqual(
-            {"text": "", "item_1": ""},
+            {"text": "", "item_1": "", "item_last": ""},
             transformer.transform_many([], options={"separator": ","}),
         )
         self.assertEqual(
-            {"text": "", "item_1": ""},
+            {"text": "", "item_1": "", "item_last": ""},
             transformer.transform_many([""], options={"separator": ","}),
         )
         self.assertEqual(
-            {"text": "", "item_1": ""}, transformer.transform_many("")
+            {"text": "", "item_1": "", "item_last": ""}, transformer.transform_many("")
         )
 
     def test_lineitem_to_string_v2_many_empty(self):
         transformer = lineitem_to_string_v2.UtilLineItemToStringV2Transform()
 
         self.assertEqual(
-            {"text": ",c,d", "item_1": "", "item_2": "c", "item_3": "d"},
+            {
+                "text": ",c,d",
+                "item_1": "",
+                "item_2": "c",
+                "item_3": "d",
+                "item_last": "d",
+            },
             transformer.transform_many(["", "c", "d"], options={"separator": ","}),
         )
         self.assertEqual(
-            {"text": ",,c,d", "item_1": "", "item_2": "", "item_3": "c,d"},
+            {
+                "text": ",,c,d",
+                "item_1": "",
+                "item_2": "",
+                "item_3": "c,d",
+                "item_last": "c,d",
+            },
             transformer.transform_many(["", "", "c,d"], options={"separator": ","}),
         )
         self.assertEqual(
-            {"text": ",", "item_1": "", "item_2": ""},
+            {"text": ",", "item_1": "", "item_2": "", "item_last": ""},
             transformer.transform_many(["", ""], options={"separator": ","}),
         )
         self.assertEqual(
-            {"text": "c,d,", "item_1": "c", "item_2": "d", "item_3": ""},
+            {
+                "text": "c,d,",
+                "item_1": "c",
+                "item_2": "d",
+                "item_3": "",
+                "item_last": "",
+            },
             transformer.transform_many(["c", "d", ""], options={"separator": ","}),
         )
 
     def test_lineitem_to_string_v2_one(self):
         transformer = lineitem_to_string_v2.UtilLineItemToStringV2Transform()
         self.assertEqual(
-            {"text": "a", "item_1": "a"},
+            {"text": "a", "item_1": "a", "item_last": "a"},
             transformer.transform_many(["a"], options={"separator": ","}),
         )
 
     def test_lineitem_to_string_v2_many(self):
         transformer = lineitem_to_string_v2.UtilLineItemToStringV2Transform()
         self.assertEqual(
-            {"text": "a,b,c,d", "item_1": "a,b", "item_2": "c,d"},
+            {"text": "a,b,c,d", "item_1": "a,b", "item_2": "c,d", "item_last": "c,d"},
             transformer.transform_many(["a,b", "c,d"], options={"separator": ","}),
         )
         self.assertEqual(
@@ -58,13 +76,14 @@ class TestUtilLineItemToStringV2Transform(unittest.TestCase):
                 "item_2": "b",
                 "item_3": "c",
                 "item_4": "d",
+                "item_last": "d",
             },
             transformer.transform_many(
                 ["a", "b", "c", "d"], options={"separator": ","}
             ),
         )
         self.assertEqual(
-            {"text": "a,b,c,d", "item_1": "a,b,c,d"},
+            {"text": "a,b,c,d", "item_1": "a,b,c,d", "item_last": "a,b,c,d"},
             transformer.transform_many(["a,b,c,d"], options={"separator": ","}),
         )
 
@@ -77,6 +96,7 @@ class TestUtilLineItemToStringV2Transform(unittest.TestCase):
                 "item_2": "b",
                 "item_3": "c",
                 "item_4": "d",
+                "item_last": "d",
             },
             transformer.transform_many(
                 ["a", "b", "c", "d"], options={"separator": "[:space:]"}
@@ -89,6 +109,7 @@ class TestUtilLineItemToStringV2Transform(unittest.TestCase):
                 "item_2": "b",
                 "item_3": "c",
                 "item_4": "d",
+                "item_last": "d",
             },
             transformer.transform_many(
                 ["a", "b", "c", "d"], options={"separator": "[:s:]"}
@@ -101,6 +122,7 @@ class TestUtilLineItemToStringV2Transform(unittest.TestCase):
                 "item_2": "b",
                 "item_3": "c",
                 "item_4": "d",
+                "item_last": "d",
             },
             transformer.transform_many(
                 ["a", "b", "c", "d"], options={"separator": ";"}
@@ -110,6 +132,6 @@ class TestUtilLineItemToStringV2Transform(unittest.TestCase):
     def test_lineitem_to_string_v2_nolineitem(self):
         transformer = lineitem_to_string_v2.UtilLineItemToStringV2Transform()
         self.assertEqual(
-            {"text": "abcd", "item_1": "abcd"},
+            {"text": "abcd", "item_1": "abcd", "item_last": "abcd"},
             transformer.transform_many("abcd", options={"separator": "[:space:]"}),
         )

--- a/transformer/transforms/util/lineitem_to_string_v2_test.py
+++ b/transformer/transforms/util/lineitem_to_string_v2_test.py
@@ -7,53 +7,53 @@ class TestUtilLineItemToStringV2Transform(unittest.TestCase):
         transformer = lineitem_to_string_v2.UtilLineItemToStringV2Transform()
 
         self.assertEqual(
-            {"text_output": "", "item 1": ""},
+            {"text": "", "item 1": ""},
             transformer.transform_many([], options={"separator": ","}),
         )
         self.assertEqual(
-            {"text_output": "", "item 1": ""},
+            {"text": "", "item 1": ""},
             transformer.transform_many([""], options={"separator": ","}),
         )
         self.assertEqual(
-            {"text_output": "", "item 1": ""}, transformer.transform_many("")
+            {"text": "", "item 1": ""}, transformer.transform_many("")
         )
 
     def test_lineitem_to_string_v2_many_empty(self):
         transformer = lineitem_to_string_v2.UtilLineItemToStringV2Transform()
 
         self.assertEqual(
-            {"text_output": ",c,d", "item 1": "", "item 2": "c", "item 3": "d"},
+            {"text": ",c,d", "item 1": "", "item 2": "c", "item 3": "d"},
             transformer.transform_many(["", "c", "d"], options={"separator": ","}),
         )
         self.assertEqual(
-            {"text_output": ",,c,d", "item 1": "", "item 2": "", "item 3": "c,d"},
+            {"text": ",,c,d", "item 1": "", "item 2": "", "item 3": "c,d"},
             transformer.transform_many(["", "", "c,d"], options={"separator": ","}),
         )
         self.assertEqual(
-            {"text_output": ",", "item 1": "", "item 2": ""},
+            {"text": ",", "item 1": "", "item 2": ""},
             transformer.transform_many(["", ""], options={"separator": ","}),
         )
         self.assertEqual(
-            {"text_output": "c,d,", "item 1": "c", "item 2": "d", "item 3": ""},
+            {"text": "c,d,", "item 1": "c", "item 2": "d", "item 3": ""},
             transformer.transform_many(["c", "d", ""], options={"separator": ","}),
         )
 
     def test_lineitem_to_string_v2_one(self):
         transformer = lineitem_to_string_v2.UtilLineItemToStringV2Transform()
         self.assertEqual(
-            {"text_output": "a", "item 1": "a"},
+            {"text": "a", "item 1": "a"},
             transformer.transform_many(["a"], options={"separator": ","}),
         )
 
     def test_lineitem_to_string_v2_many(self):
         transformer = lineitem_to_string_v2.UtilLineItemToStringV2Transform()
         self.assertEqual(
-            {"text_output": "a,b,c,d", "item 1": "a,b", "item 2": "c,d"},
+            {"text": "a,b,c,d", "item 1": "a,b", "item 2": "c,d"},
             transformer.transform_many(["a,b", "c,d"], options={"separator": ","}),
         )
         self.assertEqual(
             {
-                "text_output": "a,b,c,d",
+                "text": "a,b,c,d",
                 "item 1": "a",
                 "item 2": "b",
                 "item 3": "c",
@@ -64,7 +64,7 @@ class TestUtilLineItemToStringV2Transform(unittest.TestCase):
             ),
         )
         self.assertEqual(
-            {"text_output": "a,b,c,d", "item 1": "a,b,c,d"},
+            {"text": "a,b,c,d", "item 1": "a,b,c,d"},
             transformer.transform_many(["a,b,c,d"], options={"separator": ","}),
         )
 
@@ -72,7 +72,7 @@ class TestUtilLineItemToStringV2Transform(unittest.TestCase):
         transformer = lineitem_to_string_v2.UtilLineItemToStringV2Transform()
         self.assertEqual(
             {
-                "text_output": "a b c d",
+                "text": "a b c d",
                 "item 1": "a",
                 "item 2": "b",
                 "item 3": "c",
@@ -84,7 +84,7 @@ class TestUtilLineItemToStringV2Transform(unittest.TestCase):
         )
         self.assertEqual(
             {
-                "text_output": "a b c d",
+                "text": "a b c d",
                 "item 1": "a",
                 "item 2": "b",
                 "item 3": "c",
@@ -96,7 +96,7 @@ class TestUtilLineItemToStringV2Transform(unittest.TestCase):
         )
         self.assertEqual(
             {
-                "text_output": "a;b;c;d",
+                "text": "a;b;c;d",
                 "item 1": "a",
                 "item 2": "b",
                 "item 3": "c",
@@ -110,6 +110,6 @@ class TestUtilLineItemToStringV2Transform(unittest.TestCase):
     def test_lineitem_to_string_v2_nolineitem(self):
         transformer = lineitem_to_string_v2.UtilLineItemToStringV2Transform()
         self.assertEqual(
-            {"text_output": "abcd", "item 1": "abcd"},
+            {"text": "abcd", "item 1": "abcd"},
             transformer.transform_many("abcd", options={"separator": "[:space:]"}),
         )

--- a/transformer/transforms/util/lineitem_to_string_v2_test.py
+++ b/transformer/transforms/util/lineitem_to_string_v2_test.py
@@ -7,64 +7,64 @@ class TestUtilLineItemToStringV2Transform(unittest.TestCase):
         transformer = lineitem_to_string_v2.UtilLineItemToStringV2Transform()
 
         self.assertEqual(
-            {"text": "", "item 1": ""},
+            {"text": "", "item_1": ""},
             transformer.transform_many([], options={"separator": ","}),
         )
         self.assertEqual(
-            {"text": "", "item 1": ""},
+            {"text": "", "item_1": ""},
             transformer.transform_many([""], options={"separator": ","}),
         )
         self.assertEqual(
-            {"text": "", "item 1": ""}, transformer.transform_many("")
+            {"text": "", "item_1": ""}, transformer.transform_many("")
         )
 
     def test_lineitem_to_string_v2_many_empty(self):
         transformer = lineitem_to_string_v2.UtilLineItemToStringV2Transform()
 
         self.assertEqual(
-            {"text": ",c,d", "item 1": "", "item 2": "c", "item 3": "d"},
+            {"text": ",c,d", "item_1": "", "item_2": "c", "item_3": "d"},
             transformer.transform_many(["", "c", "d"], options={"separator": ","}),
         )
         self.assertEqual(
-            {"text": ",,c,d", "item 1": "", "item 2": "", "item 3": "c,d"},
+            {"text": ",,c,d", "item_1": "", "item_2": "", "item_3": "c,d"},
             transformer.transform_many(["", "", "c,d"], options={"separator": ","}),
         )
         self.assertEqual(
-            {"text": ",", "item 1": "", "item 2": ""},
+            {"text": ",", "item_1": "", "item_2": ""},
             transformer.transform_many(["", ""], options={"separator": ","}),
         )
         self.assertEqual(
-            {"text": "c,d,", "item 1": "c", "item 2": "d", "item 3": ""},
+            {"text": "c,d,", "item_1": "c", "item_2": "d", "item_3": ""},
             transformer.transform_many(["c", "d", ""], options={"separator": ","}),
         )
 
     def test_lineitem_to_string_v2_one(self):
         transformer = lineitem_to_string_v2.UtilLineItemToStringV2Transform()
         self.assertEqual(
-            {"text": "a", "item 1": "a"},
+            {"text": "a", "item_1": "a"},
             transformer.transform_many(["a"], options={"separator": ","}),
         )
 
     def test_lineitem_to_string_v2_many(self):
         transformer = lineitem_to_string_v2.UtilLineItemToStringV2Transform()
         self.assertEqual(
-            {"text": "a,b,c,d", "item 1": "a,b", "item 2": "c,d"},
+            {"text": "a,b,c,d", "item_1": "a,b", "item_2": "c,d"},
             transformer.transform_many(["a,b", "c,d"], options={"separator": ","}),
         )
         self.assertEqual(
             {
                 "text": "a,b,c,d",
-                "item 1": "a",
-                "item 2": "b",
-                "item 3": "c",
-                "item 4": "d",
+                "item_1": "a",
+                "item_2": "b",
+                "item_3": "c",
+                "item_4": "d",
             },
             transformer.transform_many(
                 ["a", "b", "c", "d"], options={"separator": ","}
             ),
         )
         self.assertEqual(
-            {"text": "a,b,c,d", "item 1": "a,b,c,d"},
+            {"text": "a,b,c,d", "item_1": "a,b,c,d"},
             transformer.transform_many(["a,b,c,d"], options={"separator": ","}),
         )
 
@@ -73,10 +73,10 @@ class TestUtilLineItemToStringV2Transform(unittest.TestCase):
         self.assertEqual(
             {
                 "text": "a b c d",
-                "item 1": "a",
-                "item 2": "b",
-                "item 3": "c",
-                "item 4": "d",
+                "item_1": "a",
+                "item_2": "b",
+                "item_3": "c",
+                "item_4": "d",
             },
             transformer.transform_many(
                 ["a", "b", "c", "d"], options={"separator": "[:space:]"}
@@ -85,10 +85,10 @@ class TestUtilLineItemToStringV2Transform(unittest.TestCase):
         self.assertEqual(
             {
                 "text": "a b c d",
-                "item 1": "a",
-                "item 2": "b",
-                "item 3": "c",
-                "item 4": "d",
+                "item_1": "a",
+                "item_2": "b",
+                "item_3": "c",
+                "item_4": "d",
             },
             transformer.transform_many(
                 ["a", "b", "c", "d"], options={"separator": "[:s:]"}
@@ -97,10 +97,10 @@ class TestUtilLineItemToStringV2Transform(unittest.TestCase):
         self.assertEqual(
             {
                 "text": "a;b;c;d",
-                "item 1": "a",
-                "item 2": "b",
-                "item 3": "c",
-                "item 4": "d",
+                "item_1": "a",
+                "item_2": "b",
+                "item_3": "c",
+                "item_4": "d",
             },
             transformer.transform_many(
                 ["a", "b", "c", "d"], options={"separator": ";"}
@@ -110,6 +110,6 @@ class TestUtilLineItemToStringV2Transform(unittest.TestCase):
     def test_lineitem_to_string_v2_nolineitem(self):
         transformer = lineitem_to_string_v2.UtilLineItemToStringV2Transform()
         self.assertEqual(
-            {"text": "abcd", "item 1": "abcd"},
+            {"text": "abcd", "item_1": "abcd"},
             transformer.transform_many("abcd", options={"separator": "[:space:]"}),
         )


### PR DESCRIPTION
Made a small change in registry.py to allow for hiding old transforms that we replace with newer versions while still allowing the "legacy" versions to work for existing Zaps and by using "custom values".

Create V2 of line item to string where we always output the joined text and also each item in the array as a separate field. This output would not be compatible with existing Zaps.

The transform will always output at least 1 separate field along with the text value.