### PR TITLE
Update Weurkzug and Flask for security updates

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ Babel==2.2.0
 beautifulsoup4==4.4.1
 blinker==1.4
 contextlib2==0.5.1
-Flask==0.12.4
+Flask==1.1.1
 gunicorn==19.9.0
 inflect==0.2.5
 itsdangerous==0.24
@@ -18,7 +18,7 @@ pytz==2015.7
 six==1.10.0
 titlecase==0.8.1
 Unidecode==0.04.21
-Werkzeug==0.11.3
+Werkzeug==0.16.0
 wheel==0.24.0
 phonenumbers==8.10.16
 parsedatetime==2.1


### PR DESCRIPTION
Need to upgrade Wearkzug (0.16.0) due to high level security warning.

Flask also (v1.1.1), although lower-level warning.