### PR TITLE
[phone number validation]

### DIFF
--- a/transformer/transforms/number/phone.py
+++ b/transformer/transforms/number/phone.py
@@ -10,13 +10,13 @@ class PhoneNumberFormattingTransform(BaseTransform):
     category = 'number'
     name = 'phone'
     label = 'Format Phone Number'
-    help_text = ('Format a phone number to a new style. The number should be a valid phone number for country code (default is US), or '
+    help_text = ('Format a phone number to a new style. Validation is on by default, if checked and number is invalid, '
     'phone number will be returned unchanged.')
 
     noun = 'Phone Number'
     verb = 'format to a new style'
 
-    def transform(self, phone_string, format_string=u'', default_region=u'US', **kwargs):
+    def transform(self, phone_string, format_string=u'', default_region=u'US', validate=True, **kwargs):
         if phone_string is None:
             return u''
 
@@ -26,8 +26,9 @@ class PhoneNumberFormattingTransform(BaseTransform):
             # Return original input if we can't do anything with it
             return phone_string
 
-        if not phonenumbers.is_possible_number(number) or not phonenumbers.is_valid_number(number):
-            return phone_string
+        if validate:
+            if not phonenumbers.is_possible_number(number) or not phonenumbers.is_valid_number(number):
+                return phone_string
 
         try:
             format_int = int(format_string)
@@ -114,6 +115,13 @@ class PhoneNumberFormattingTransform(BaseTransform):
                 'required': False,
                 'default': 'US',
                 'choices': available_countries,
+            },
+            {
+                "type": "bool",
+                "required": False,
+                "key": "validate",
+                "label": "Validate phone number?",
+                "default": "yes",
             },
         ]
 

--- a/transformer/transforms/number/phone_test.py
+++ b/transformer/transforms/number/phone_test.py
@@ -3,6 +3,8 @@ import phone
 
 #we should do some external validation against https://libphonenumber.appspot.com/
 
+#update on 10/5 - added new tests when validate option is set to True
+
 class TestPhoneNumberFormattingTransform(unittest.TestCase):
     def test_phone(self):
         transformer = phone.PhoneNumberFormattingTransform()
@@ -119,6 +121,25 @@ class TestPhoneNumberFormattingTransform(unittest.TestCase):
         for input_number, format_string, expected_output in tests:
             out = transformer.transform(input_number, format_string=format_string)
             self.assertEqual(out, input_number)
+
+    def test_invalid_phone_dont_validate(self):
+        # set validation to false, we should format these bogus numbers, even if we know they are wrong
+        # but still return string if phone number is not entered
+        transformer = phone.PhoneNumberFormattingTransform()
+
+        tests = [
+            # invalid phone numbers
+            # input, format, expected output
+            ('(999) 999-9999', '1', False, '+1 999-999-9999'),
+            ('1-22-555-1212', '1', False, '+1 1225551212'),
+            ('fred', '1', False, 'fred')
+
+        ]
+
+        for input_number, format_string, validate, expected_output in tests:
+            self.assertEqual(expected_output, transformer.transform(input_number, format_string=format_string, validate=False))
+
+        
 
     def test_empty_phone(self):
         transformer = phone.PhoneNumberFormattingTransform()


### PR DESCRIPTION
This is for: https://admin.zapier.com/rover/app/ZapierFormatterDevAPI/issues/141/

Removed validation requirements. There will still be cases where we return the entered string (if it's not even a number), but in number cases we'll try to format the numbers accordingly. This could result in unusable numbers, but many users need this for testing, and for numbers they are not using in a SMS type Zap