### PR TITLE
STAR-14495 Allow testing live requests against an alternate deployment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 *.pyc
-env27
-.DS_Store
-.vscode
+env27/
+.DS_Store/
+.vscode/
+.idea/

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,7 @@ Babel==2.2.0
 beautifulsoup4==4.4.1
 blinker==1.4
 contextlib2==0.5.1
+deepdiff==3.3.0
 Flask==1.1.1
 gunicorn==19.9.0
 html2text==2017.10.4
@@ -18,6 +19,7 @@ phonenumbers==8.10.16
 python-dateutil==2.4.2
 pytz==2015.7
 raven==5.10.2
+requests==2.24.0
 simplejson==3.11.1
 six==1.10.0
 titlecase==0.8.1

--- a/transformer/app.py
+++ b/transformer/app.py
@@ -45,6 +45,7 @@ if sentry_dsn:
 registry.make_registry()
 
 live_integration_test_server = os.environ.get('LIVE_INTEGRATION_TEST_SERVER')
+live_integration_test_timeout = os.environ.get('LIVE_INTEGRATION_TEST_TIMEOUT', 10)
 
 
 @app.after_request
@@ -55,7 +56,8 @@ def perform_live_integration_test(response):
                 method=request.method,
                 url=live_integration_test_server + request.path,
                 params=request.args,
-                data=request.data
+                data=request.data,
+                timeout=live_integration_test_timeout
             )
 
             if response.status_code == test_response.status_code:


### PR DESCRIPTION
A PR has been created that upgrades Formatter to Python 3: https://github.com/zapier/transformer/pull/129

However, since the tests as well as the production code have been updated, it is hard to say for sure that they are testing the same behavior.  In addition, there are numerous dependencies - none have been updated yet, but most do not officially support Python 3.6 at their current version, and updating them could introduce breaking changes to Formatter functionality not covered by our test suite.

To build confidence in the new version, it has been deployed on Heroku as a review app with the same dyno count/size as production.  To test it with production data, *this* PR introduces a small piece of middleware that forwards all requests to a specified server, and logs whether the responses generated are identical or not.  We can deploy this to production and monitor whether any bugs have been found in the Python 3.6 review app.  After fixing any bugs found, and some period of time without any discrepancies logged, we can proceed to deploy the Python 3 version in production.

Please see all three related Jira tickets:
https://zapierorg.atlassian.net/browse/STAR-14494
https://zapierorg.atlassian.net/browse/STAR-14495
https://zapierorg.atlassian.net/browse/STAR-14496