### PR TITLE
Revert "STAR-14495 Allow testing live requests against an alternate deployment"

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,4 @@
 *.pyc
-env27/
-.DS_Store/
-.vscode/
-.idea/
+env27
+.DS_Store
+.vscode

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,6 @@ Babel==2.2.0
 beautifulsoup4==4.4.1
 blinker==1.4
 contextlib2==0.5.1
-deepdiff==3.3.0
 Flask==1.1.1
 gunicorn==19.9.0
 html2text==2017.10.4
@@ -19,7 +18,6 @@ phonenumbers==8.10.16
 python-dateutil==2.4.2
 pytz==2015.7
 raven==5.10.2
-requests==2.24.0
 simplejson==3.11.1
 six==1.10.0
 titlecase==0.8.1

--- a/transformer/app.py
+++ b/transformer/app.py
@@ -3,12 +3,6 @@ import os
 import sys
 import json
 
-from logging.config import dictConfig
-
-import requests
-
-from deepdiff import DeepDiff
-
 # insert the root dir into the system path
 sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
 
@@ -21,20 +15,6 @@ from flask import Flask, jsonify, request
 # Create our Flask App
 app = Flask(__name__)
 
-dictConfig({
-    'version': 1,
-    'formatters': {'default': {}},
-    'handlers': {'wsgi': {
-        'class': 'logging.StreamHandler',
-        'stream': 'ext://flask.logging.wsgi_errors_stream',
-        'formatter': 'default'
-    }},
-    'root': {
-        'level': 'DEBUG',
-        'handlers': ['wsgi']
-    }
-})
-
 sentry_dsn = os.environ.get('SENTRY_DSN')
 if sentry_dsn:
     from raven.contrib.flask import Sentry
@@ -43,40 +23,6 @@ if sentry_dsn:
 
 # Prepare the application transform registry
 registry.make_registry()
-
-live_integration_test_server = os.environ.get('LIVE_INTEGRATION_TEST_SERVER')
-live_integration_test_timeout = os.environ.get('LIVE_INTEGRATION_TEST_TIMEOUT', 10)
-
-
-@app.after_request
-def perform_live_integration_test(response):
-    if live_integration_test_server:
-        try:
-            test_response = requests.request(
-                method=request.method,
-                url=live_integration_test_server + request.path,
-                params=request.args,
-                data=request.data,
-                timeout=live_integration_test_timeout
-            )
-
-            if response.status_code == test_response.status_code:
-                app.logger.debug('[perform_live_integration_test] Status codes match!')
-            else:
-                app.logger.error(
-                    '[perform_live_integration_test] Status codes do not match: %s != %s',
-                    response.status_code,
-                    test_response.status_code
-                )
-
-            body_diff = DeepDiff(response.json, test_response.json(), ignore_order=True)
-            if not body_diff:
-                app.logger.debug('[perform_live_integration_test] Bodies match!')
-            else:
-                app.logger.error('[perform_live_integration_test] Bodies do not match: %s', body_diff)
-        except Exception as e:
-            app.logger.error('[perform_live_integration_test] Exception trying to run live integration test: %s', e)
-    return response
 
 
 @app.route('/')


### PR DESCRIPTION
Reverts zapier/transformer#131, since it resulted in a worker backlog/timeouts and subsequent held tasks.

I will create an alternative implementation of this that does the request to the test server and logs the results asynchronously, but for now I want to make sure this is reverted so it doesn't get re-deployed by accident.