### PR TITLE
STAR-14495 Adds Celery for asynchronous Python 3 testing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 *.pyc
-env27
-.DS_Store
-.vscode
+env27/
+.DS_Store/
+.vscode/
+.idea/

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,4 +7,4 @@ install:
   pip install -r requirements.txt
 
 script:
-  bash run_tests.sh
+  python -m unittest discover . '*_test.py'

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,4 +7,4 @@ install:
   pip install -r requirements.txt
 
 script:
-  python -m unittest discover . '*_test.py'
+  ./run_tests.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,14 @@
+FROM python:2.7.17
+
+ENV DEBIAN_FRONTEND noninteractive
+RUN export DEBIAN_FRONTEND=noninteractive
+
+ADD requirements.txt /tmp/requirements.txt
+RUN pip install pip -U && \
+    pip install -r /tmp/requirements.txt && \
+    rm /tmp/requirements.txt
+
+VOLUME /usr/src/app
+WORKDIR /usr/src/app
+
+CMD /usr/src/app/docker/bootstrap.sh

--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,2 @@
 web: newrelic-admin run-program gunicorn transformer.app:app --workers=6 --graceful-timeout=29 --timeout=31
+worker: newrelic-admin run-program celery -A transformer.app.celery worker --loglevel=info --concurrency=4

--- a/README.md
+++ b/README.md
@@ -22,22 +22,18 @@ Transformer is a little web app that performs data transformations. You specify 
 ## Setup
 
 ```
-virtualenv --python=python2.7 env27
-. env27/bin/activate
-pip install -r requirements.txt
+docker-compose build
 ```
 
 ## Run Locally
 
 ```
-. env27/bin/activate
-DEBUG=true PORT=8888 python transformer/app.py
+docker-compose up -d
 ```
 
 ## Test Locally
 
 ```
-. env27/bin/activate
 ./run_tests.sh
 ```
 

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ docker-compose up -d
 ## Test Locally
 
 ```
-./run_tests.sh
+docker-compose run web ./run_tests.sh
 ```
 
 ## Contributing

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,26 @@
+version: '3'
+
+services:
+  web:
+    build: .
+    volumes:
+      - .:/usr/src/app
+    environment:
+      DEBUG: "true"
+      REDIS_URL: "redis://redis:6379"
+    ports:
+      - "5000:5000"
+
+  worker:
+    build: .
+    volumes:
+      - .:/usr/src/app
+    command: celery -A transformer.app.celery worker --loglevel=info
+    environment:
+      C_FORCE_ROOT: "true"
+      REDIS_URL: "redis://redis:6379"
+    depends_on:
+      - redis
+
+  redis:
+    image: redis:5.0

--- a/docker/bootstrap.sh
+++ b/docker/bootstrap.sh
@@ -1,0 +1,4 @@
+#! /bin/bash
+
+pip install -r requirements.txt
+exec python transformer/app.py

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,9 @@ arrow==0.7.0
 Babel==2.2.0
 beautifulsoup4==4.4.1
 blinker==1.4
+celery==4.4.7
 contextlib2==0.5.1
+deepdiff==3.3.0
 Flask==1.1.1
 gunicorn==19.9.0
 html2text==2017.10.4
@@ -18,6 +20,8 @@ phonenumbers==8.10.16
 python-dateutil==2.4.2
 pytz==2015.7
 raven==5.10.2
+redis==3.5.3
+requests==2.24.0
 simplejson==3.11.1
 six==1.10.0
 titlecase==0.8.1

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -1,1 +1,1 @@
-python -m unittest discover . '*_test.py'
+docker-compose run web python -m unittest discover . '*_test.py'

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -1,1 +1,3 @@
-docker-compose run web python -m unittest discover . '*_test.py'
+#! /bin/bash
+
+python -m unittest discover . '*_test.py'

--- a/transformer/app.py
+++ b/transformer/app.py
@@ -55,7 +55,7 @@ def str_to_unicode(data):
 def perform_async_live_integration_server_test(method, path, args, data, expected_status_code, expected_json):
     response = requests.request(method=method, url=live_integration_test_server + path, params=args, data=data)
 
-    body_diff = DeepDiff(expected_json, response.json(), ignore_order=True)
+    body_diff = DeepDiff(str_to_unicode(expected_json), response.json(), ignore_order=True)
     full_match = expected_status_code == response.status_code and not body_diff
 
     if full_match:

--- a/transformer/app.py
+++ b/transformer/app.py
@@ -1,7 +1,13 @@
 from __future__ import absolute_import
+
+import collections
 import os
 import sys
 import json
+
+from celery import Celery
+from deepdiff import DeepDiff
+import requests
 
 # insert the root dir into the system path
 sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
@@ -20,9 +26,55 @@ if sentry_dsn:
     from raven.contrib.flask import Sentry
     sentry = Sentry(app, dsn=sentry_dsn)
 
+app.config['CELERY_BROKER_URL'] = os.environ.get('REDIS_URL')
+
+celery = Celery('transformer.app', broker=app.config['CELERY_BROKER_URL'])
+celery.conf.update(app.config)
+
 
 # Prepare the application transform registry
 registry.make_registry()
+
+# Configure live integration testing
+
+live_integration_test_server = os.environ.get('LIVE_INTEGRATION_TEST_SERVER')
+
+
+def str_to_unicode(data):
+    if isinstance(data, basestring):
+        return unicode(data)
+    elif isinstance(data, collections.Mapping):
+        return dict(map(str_to_unicode, data.iteritems()))
+    elif isinstance(data, collections.Iterable):
+        return type(data)(map(str_to_unicode, data))
+    else:
+        return data
+
+
+@celery.task
+def perform_async_live_integration_server_test(method, path, args, data, expected_status_code, expected_json):
+    response = requests.request(method=method, url=live_integration_test_server + path, params=args, data=data)
+
+    body_diff = DeepDiff(expected_json, response.json(), ignore_order=True)
+    full_match = expected_status_code == response.status_code and not body_diff
+
+    if full_match:
+        print '[perform_live_integration_test] Responses match!'
+    else:
+        output = '[perform_live_integration_test] Responses do not match:\n' \
+                 'path: %s\ndata: %s\nexpected status code: %s\nactual status code: %s\njson diff: %s' % \
+                 (path, data, expected_status_code, response.status_code, body_diff)
+
+        print output
+
+
+@app.after_request
+def perform_live_integration_test(response):
+    if live_integration_test_server:
+        perform_async_live_integration_server_test.delay(
+            request.method, request.path, request.args, request.data, response.status_code, response.json)
+
+    return response
 
 
 @app.route('/')


### PR DESCRIPTION
The previous attempt (#131) to enable live testing of differences between the Python 2 production version and the Python 3 development branch proved unsuitable, since during times of heavy load there are no seconds to spare when returning a production request.

This attempt adds Celery via Redis, as an asynchronous task queue that can check and log differences between the Python 2 and Python 3 responses asynchronously (outside of the http server process).

Local development instructions have been updated to use Docker, to simplify setting up Redis.